### PR TITLE
CCBC-999: Update subdocument examples

### DIFF
--- a/modules/ROOT/pages/subdocument-operations.adoc
+++ b/modules/ROOT/pages/subdocument-operations.adoc
@@ -1,1 +1,1141 @@
-include::6.0@sdk:pages:partial$subdocument-operations.adoc[]
+= Sub-Document Operations
+include::partial$attributes.adoc[]
+
+[abstract]
+_Sub-document_ operations can be used to efficiently access _parts_ of documents.
+Sub-document operations may be quicker and more network-efficient than _full-document_ operations such as _upsert_, _update_ and _get_ because they only transmit the accessed sections of the document over the network.
+Sub-document operations are also atomic, allowing safe modifications to documents with built-in concurrency control.
+
+== Sub-documents
+
+Starting with Couchbase Server 4.5 you can atomically and efficiently update and retrieve _parts_ of a document.
+These parts are called _sub-documents_.
+While full-document retrievals retrieve the entire document and full document updates require sending the entire document, sub-document retrievals only retrieve relevant parts of a document and sub-document updates only require sending the updated portions of a document.
+You should use sub-document operations when you are modifying only portions of a document, and full-document operations when the contents of a document is to change significantly.
+
+[caption=Attention]
+IMPORTANT: The sub-document operations described on this page are for _Key-Value_ requests only: they are not related to sub-document N1QL queries.
+(Sub-document N1QL queries are explained in the section xref:n1ql-query.adoc[Querying with N1QL].)
+
+In order to use sub-document operations you need to specify a _path_ indicating the location of the sub-document.
+The _path_ follows N1QL syntax (see https://developer.couchbase.com/documentation/server/current/sdk/subdocument-operations.html#story-h2-12[below^], and xref:{version-server}@server:n1ql:n1ql-intro/queriesandresults.adoc[N1QL Queries and Results]).
+Considering the document:
+
+.customer123.json
+[source,json]
+----
+{
+  "name": "Douglas Reynholm",
+  "email": "douglas@reynholmindustries.com",
+  "addresses": {
+    "billing": {
+      "line1": "123 Any Street",
+      "line2": "Anytown",
+      "country": "United Kingdom"
+    },
+    "delivery": {
+      "line1": "123 Any Street",
+      "line2": "Anytown",
+      "country": "United Kingdom"
+    }
+  },
+  "purchases": {
+    "complete": [
+      339, 976, 442, 666
+    ],
+    "abandoned": [
+      157, 42, 999
+    ]
+  }
+}
+----
+
+The paths `name`, `addresses.billing.country` and `purchases.complete[0]` are all valid paths.
+
+In examples below we will assume common operation callback will be set for all operations (mutations and lookups):
+
+[source,cpp]
+----
+#include <inttypes.h> /* for PRI* macros */
+
+void subdoc_callback(lcb_t instance, int cbtype, const lcb_RESPBASE *rb)
+{
+    const lcb_RESPSUBDOC *resp = (const lcb_RESPSUBDOC *)rb;
+
+    if (rb->rc == LCB_SUCCESS) {
+	printf("%.*s. CAS=0x%" PRIx64 "\n",
+	    (int)rb->nkey, (char *)rb->key, rb->cas);
+    } else {
+	printf("%.*s. ERROR: %s\n", (int)rb->nkey, (char *)rb->key,
+            lcb_strerror_short(rb->rc));
+    }
+    lcb_SDENTRY cur;
+    size_t vii = 0, oix = 0;
+    while (lcb_sdresult_next(resp, &cur, &vii)) {
+        int index = oix++;
+        /* mutations might skip explit entry if everything is good,
+           but when they do have entry, 'index' must be used */
+        if (cbtype == LCB_CALLBACK_SDMUTATE) {
+            index = cur.index;
+        }
+        printf("%d. Size=%lu, RC=%s\n", index, (unsigned long)cur.nvalue,
+               lcb_strerror_short(cur.status));
+        if (cur.nvalue > 0) {
+            fwrite(cur.value, 1, cur.nvalue, stdout);
+            printf("\n");
+        }
+    }
+}
+
+...
+
+lcb_install_callback3(instance, LCB_CALLBACK_SDLOOKUP, subdoc_callback);
+lcb_install_callback3(instance, LCB_CALLBACK_SDMUTATE, subdoc_callback);
+----
+
+== Retrieving
+
+The _lookup-in_ operations queries the document for a certain path(s) and returns that/those path(s).
+You have a choice of actually retrieving the document path using the _subdoc-get_ sub-document operation, or simply querying the existence of the path using the _subdoc-exists_ sub-document operation.
+The latter saves even more bandwidth by not retrieving the contents of the path if it is not needed.
+
+.Retrieve sub-document value
+[source,bash]
+----
+$ cbc subdoc
+subdoc> get -p addresses.delivery.country customer123
+customer123          CAS=0x156a08a8e3830000
+0. Size=16, RC=0x00 Success (Not an error)
+"United Kingdom"
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_GET;
+const char *path = "addresses.delivery.country";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+.output
+....
+customer123. CAS=0x156a08a8e3830000
+0. Size=16, RC=LCB_SUCCESS (0x00)
+"United Kingdom"
+....
+
+.Check existence of sub-document path
+[source,bash]
+----
+$ cbc subdoc
+subdoc> exist -p purchases.pending[-1] customer123
+customer123          CAS=0x0
+0. Size=0, RC=0x3f Sub-document path does not exist
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_EXISTS;
+const char *path = "purchases.pending[-1]";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+.output
+....
+customer123. ERROR: LCB_SUBDOC_MULTI_FAILURE (0x49)
+0. Size=0, RC=LCB_SUBDOC_PATH_ENOENT (0x3F)
+....
+
+Multiple operations can be combined as well:
+
+.Combine multiple lookup operations
+[source,php]
+----
+lcb_SDSPEC specs[2] = {0};
+specs[0].sdcmd = LCB_SDCMD_GET;
+const char *path_0 = "addresses.delivery.country";
+LCB_SDSPEC_SET_PATH(&specs[0], path_0, strlen(path_0));
+specs[1].sdcmd = LCB_SDCMD_EXISTS;
+const char *path_1 = "purchases.pending[-1]";
+LCB_SDSPEC_SET_PATH(&specs[1], path_1, strlen(path_1));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 2;
+cmd.specs = specs;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+.output
+....
+customer123. ERROR: LCB_SUBDOC_MULTI_FAILURE (0x49)
+0. Size=16, RC=LCB_SUCCESS (0x00)
+"United Kingdom"
+1. Size=0, RC=LCB_SUBDOC_PATH_ENOENT (0x3F)
+....
+
+== Mutating
+
+Mutation operations modify one or more paths in the document.
+The simplest of these operations is _subdoc-upsert_, which, just like the fulldoc-level _upsert_, this will either modify the value of an existing path or create it if it does not exist:
+
+.Upserting a new sub-document
+[source,bash]
+----
+$ cbc subdoc
+subdoc> dict-upsert -p fax="311-55-0151" customer123
+customer123          CAS=0x156a0b4081c00000
+0. Size=0, RC=0x00 Success (Not an error)
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_DICT_UPSERT;
+const char *path = "fax";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "\"311-55-0151\"";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+.output
+....
+customer123. CAS=0x156a0b69ccb30000
+0. Size=0, RC=LCB_SUCCESS (0x00)
+....
+
+Likewise, the _subdoc-insert_ operation will only add the new value to the path if it does not exist:
+
+.Inserting a sub-document
+[source,bash]
+----
+$ cbc subdoc
+subdoc> array-insert -p purchases.complete=[42,true,null] customer123
+customer123          CAS=0x0
+0. Size=0, RC=0x41 Malformed sub-document path
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_ARRAY_INSERT;
+const char *path = "purchases.complete";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "[42, true, null]";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+.output
+....
+customer123. ERROR: LCB_SUBDOC_MULTI_FAILURE (0x49)
+0. Size=0, RC=LCB_SUBDOC_PATH_EINVAL (0x41)
+....
+
+Dictionary values can also be replaced or removed, and you may combine any number of mutation operations within the same general _mutate-in_ API.
+Here's an example of one which replaces one path and removes another.
+
+[source,cpp]
+----
+lcb_SDSPEC specs[2] = {0};
+specs[0].sdcmd = LCB_SDCMD_REMOVE;
+const char *path_0 = "addresses.billing";
+LCB_SDSPEC_SET_PATH(&specs[0], path_0, strlen(path_0));
+specs[1].sdcmd = LCB_SDCMD_REPLACE;
+const char *path_1 = "email";
+LCB_SDSPEC_SET_PATH(&specs[1], path_1, strlen(path_1));
+const char *value_1 = "\"dougr96@hotmail.com\"";
+LCB_SDSPEC_SET_VALUE(&specs[1], value_1, strlen(value_1));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 2;
+cmd.specs = specs;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+.output
+....
+customer123. CAS=0x156a0c0ffa990000
+....
+
+== Array append and prepend
+
+The _subdoc-array-prepend_ and _subdoc-array-append_ operations are true array prepend and append operations.
+Unlike fulldoc _append_/_prepend_ operations (which simply concatenate bytes to the existing value), _subdoc-array-append_ and _subdoc-array-prepend_ are JSON-aware:
+
+[source,bash]
+----
+$ cbc subdoc
+subdoc> array-add-last -p purchases.complete=777 customer123
+customer123          CAS=0x156a0c5082bf0000
+0. Size=0, RC=0x00 Success (Not an error)
+
+subdoc> get -p purchases.complete customer123
+customer123          CAS=0x156a0c5082bf0000
+0. Size=21, RC=0x00 Success (Not an error)
+[339,976,442,666,777]
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+const char *path = "purchases.complete";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "777";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+.output
+....
+customer123. CAS=0x156a0ce536ee0000
+0. Size=0, RC=LCB_SUCCESS (0x00)
+....
+
+[source,bash]
+----
+$ cbc subdoc
+subdoc> array-add-first -p purchases.abandoned=18 customer123
+customer123          CAS=0x156a0c6681980000
+0. Size=0, RC=0x00 Success (Not an error)
+
+subdoc> get -p purchases.abandoned customer123
+customer123          CAS=0x156a0c6681980000
+0. Size=15, RC=0x00 Success (Not an error)
+[18,157,42,999]
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_ARRAY_ADD_FIRST;
+const char *path = "purchases.abandoned";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "18";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+.output
+....
+customer123. CAS=0x156a0cfcd2120000
+0. Size=0, RC=LCB_SUCCESS (0x00)
+....
+
+If your document only needs to contain an array, you do not have to create a top-level object wrapper to contain it.
+Simply initialize the document with an empty array and then use the empty path for subsequent sub-document array operations:
+
+.Creating and populating an array document
+[source,bash]
+----
+$ cbc subdoc
+subdoc> upsert my_array '{"ary":[]}'
+my_array             CAS=0x156a0e3c9dc70000
+
+subdoc> array-add-last -p 'ary="some element"' my_array
+my_array             CAS=0x156a0e4117160000
+0. Size=0, RC=0x00 Success (Not an error)
+
+subdoc> get my_array
+my_array             CAS=0x156a0e4117160000
+0. Size=24, RC=0x00 Success (Not an error)
+{"ary":["some element"]}
+----
+
+
+[source,cpp]
+----
+static void store_callback(lcb_t instance, int cbtype, const lcb_RESPBASE *rb)
+{
+    if (rb->rc == LCB_SUCCESS) {
+    printf("%.*s Stored. CAS=0x%" PRIx64 "\n",
+        (int)rb->nkey, (char *)rb->key, rb->cas);
+    } else {
+        printf("Unable to store document: %s\n", lcb_strerror_short(rb->rc));
+    }
+}
+
+...
+
+lcb_install_callback3(instance, LCB_CALLBACK_STORE, store_callback);
+
+...
+
+{
+    lcb_CMDSTORE cmd = {0};
+    cmd.datatype = LCB_DATATYPE_JSON;
+    const char *key = "my_array";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    const char *value = "{\"ary\":[]}";
+    LCB_CMD_SET_VALUE(&cmd, value, strlen(value));
+    err = lcb_store3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule store: %s\n", lcb_strerror_short(err));
+    }
+}
+lcb_wait(instance); /* wait for upsert operation */
+
+{
+    lcb_SDSPEC spec = {0};
+    spec.sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+    const char *path = "ary";
+    LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+    const char *value = "\"some element\"";
+    LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+    lcb_CMDSUBDOC cmd = {0};
+    const char *key = "my_array";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    cmd.nspecs = 1;
+    cmd.specs = &spec;
+    err = lcb_subdoc3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+    }
+}
+----
+.output
+....
+my_array Stored. CAS=0x156a0ed604fb0000
+my_array. CAS=0x156a0ed605020000
+0. Size=0, RC=LCB_SUCCESS (0x00)
+....
+
+If you wish to add multiple values to an array, you may do so by passing multiple values to the _array-append_, _array-prepend_, or _array-insert_ operations.
+Be sure to know the difference between passing a collection of multiple elements (in which case the collection is inserted as a single element in the array, as a sub-array) and passing multiple elements (in which case the elements are appended individually to the array):
+
+.Add multiple elements to an array
+[source,bash]
+----
+$ cbc subdoc
+subdoc> array-add-last -p 'ary="elem1","elem2","elem3"' my_array
+my_array             CAS=0x156a0ef195580000
+0. Size=0, RC=0x00 Success (Not an error)
+
+subdoc> get my_array
+my_array             CAS=0x156a0ef195580000
+0. Size=48, RC=0x00 Success (Not an error)
+{"ary":["some element","elem1","elem2","elem3"]}
+----
+
+[source,cpp]
+----
+{
+    lcb_SDSPEC spec = {0};
+    spec.sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+    const char *path = "ary";
+    LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+    const char *value = "\"elem1\",\"elem2\",\"elem3\"";
+    LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+    lcb_CMDSUBDOC cmd = {0};
+    const char *key = "my_array";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    cmd.nspecs = 1;
+    cmd.specs = &spec;
+    err = lcb_subdoc3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+    }
+}
+lcb_wait(instance); /* wait for mutation */
+
+{
+    lcb_SDSPEC spec = {0};
+    spec.sdcmd = LCB_SDCMD_GET;
+    const char *path = "ary";
+    LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+
+    lcb_CMDSUBDOC cmd = {0};
+    const char *key = "my_array";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    cmd.nspecs = 1;
+    cmd.specs = &spec;
+    err = lcb_subdoc3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+    }
+    printf("--- document:\n");
+}
+----
+.output
+....
+my_array. CAS=0x156a0ea6239b0000
+0. Size=0, RC=LCB_SUCCESS (0x00)
+--- document:
+my_array. CAS=0x156a0ea6239b0000
+0. Size=40, RC=LCB_SUCCESS (0x00)
+["some element","elem1","elem2","elem3"]
+....
+
+.Add single array as element to existing array
+[source,bash]
+----
+$ cbc subdoc
+subdoc> array-add-last -p 'ary=["elem1","elem2","elem3"]' my_array
+my_array             CAS=0x156a0f01870b0000
+0. Size=0, RC=0x00 Success (Not an error)
+
+subdoc> get my_array
+my_array             CAS=0x156a0f01870b0000
+0. Size=50, RC=0x00 Success (Not an error)
+{"ary":["some element",["elem1","elem2","elem3"]]}
+----
+
+[source,cpp]
+----
+{
+    lcb_SDSPEC spec = {0};
+    spec.sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+    const char *path = "ary";
+    LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+    const char *value = "[\"elem1\",\"elem2\",\"elem3\"]";
+    LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+    lcb_CMDSUBDOC cmd = {0};
+    const char *key = "my_array";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    cmd.nspecs = 1;
+    cmd.specs = &spec;
+    err = lcb_subdoc3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+    }
+}
+lcb_wait(instance); /* wait for mutation */
+
+{
+    lcb_SDSPEC spec = {0};
+    spec.sdcmd = LCB_SDCMD_GET;
+    const char *path = "ary";
+    LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+
+    lcb_CMDSUBDOC cmd = {0};
+    const char *key = "my_array";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    cmd.nspecs = 1;
+    cmd.specs = &spec;
+    err = lcb_subdoc3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+    }
+    printf("--- document:\n");
+}
+----
+.output
+....
+my_array. CAS=0x156a0eb878be0000
+0. Size=0, RC=LCB_SUCCESS (0x00)
+--- document:
+my_array. CAS=0x156a0eb878be0000
+0. Size=42, RC=LCB_SUCCESS (0x00)
+["some element",["elem1","elem2","elem3"]]
+....
+
+Note that passing multiple values to a single _array-append_ operation results in greater performance increase and bandwidth savings than simply specifying a single _array-append_ for each element.
+
+.Adding multiple elements to array (slow)
+[source,bash]
+----
+$ cbc subdoc
+subdoc> array-add-last -p ary="elem1" -p ary="elem2" -p ary="elem3" my_array
+my_array             CAS=0x156a0f5ae2db0000
+----
+
+[source,cpp]
+----
+lcb_SDSPEC specs[3] = {0};
+const char *path = "ary";
+specs[0].sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+LCB_SDSPEC_SET_PATH(&specs[0], path, strlen(path));
+const char *value_1 = "\"elem1\"";
+LCB_SDSPEC_SET_VALUE(&specs[0], value_1, strlen(value_1));
+specs[1].sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+LCB_SDSPEC_SET_PATH(&specs[1], path, strlen(path));
+const char *value_2 = "\"elem2\"";
+LCB_SDSPEC_SET_VALUE(&specs[1], value_2, strlen(value_2));
+specs[2].sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+LCB_SDSPEC_SET_PATH(&specs[2], path, strlen(path));
+const char *value_3 = "\"elem3\"";
+LCB_SDSPEC_SET_VALUE(&specs[2], value_3, strlen(value_3));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "my_array";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 3;
+cmd.specs = specs;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+If you wish to create an array if it does not exist and also push elements to it within the same operation you may use the<< subdoc-create-parents,_create-parents_>> option:
+
+[source,bash]
+----
+$ cbc subdoc
+subdoc> upsert some_doc {}
+some_doc             CAS=0x156a0f7f9e4a0000
+
+subdoc> array-add-last -p some.array="Hello","World" some_doc
+some_doc             CAS=0x0
+0. Size=0, RC=0x3f Sub-document path does not exist
+
+subdoc> array-add-last -i -p some.array="Hello","World" some_doc
+some_doc             CAS=0x156a0f8b52110000
+0. Size=0, RC=0x00 Success (Not an error)
+
+subdoc> get some_doc
+some_doc             CAS=0x156a0f8b52110000
+0. Size=36, RC=0x00 Success (Not an error)
+{"some":{"array":["Hello","World"]}}
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.options = LCB_SDSPEC_F_MKINTERMEDIATES;
+spec.sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+const char *path = "some.array";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "\"Hello\",\"World\"";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "some_doc";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+== Arrays as unique sets
+
+Limited support also exists for treating arrays like unique sets, using the _subdoc-array-addunique_ command.
+This will do a check to determine if the given value exists or not before actually adding the item to the array:
+
+[source,bash]
+----
+$ cbc subdoc
+subdoc> array-add-unique -p purchases.complete=95 customer123
+customer123          CAS=0x156a0fbf75cf0000
+0. Size=0, RC=0x00 Success (Not an error)
+
+subdoc> array-add-unique -p purchases.abandoned=42 customer123
+customer123          CAS=0x0
+0. Size=0, RC=0x48 The given path already exists in the document
+----
+
+[source,cpp]
+----
+{
+    lcb_SDSPEC spec = {0};
+    spec.options = LCB_SDSPEC_F_MKINTERMEDIATES;
+    spec.sdcmd = LCB_SDCMD_ARRAY_ADD_UNIQUE;
+    const char *path = "purchases.complete";
+    LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+    const char *value = "95";
+    LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+    lcb_CMDSUBDOC cmd = {0};
+    const char *key = "customer123";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    cmd.nspecs = 1;
+    cmd.specs = &spec;
+    err = lcb_subdoc3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+    }
+}
+{
+    lcb_SDSPEC spec = {0};
+    spec.options = LCB_SDSPEC_F_MKINTERMEDIATES;
+    spec.sdcmd = LCB_SDCMD_ARRAY_ADD_UNIQUE;
+    const char *path = "purchases.abandoned";
+    LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+    const char *value = "42";
+    LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+    lcb_CMDSUBDOC cmd = {0};
+    const char *key = "customer123";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    cmd.nspecs = 1;
+    cmd.specs = &spec;
+    err = lcb_subdoc3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+    }
+}
+----
+.output
+....
+customer123. CAS=0x156a0fe3b11b0000
+0. Size=0, RC=LCB_SUCCESS (0x00)
+customer123. ERROR: LCB_SUBDOC_MULTI_FAILURE (0x49)
+0. Size=0, RC=LCB_SUBDOC_PATH_EEXISTS (0x48)
+....
+
+Note that currently the _addunique_ will fail with a _Path Mismatch_ error if the array contains JSON _floats_, _objects_, or _arrays_.
+The _addunique_ operation will also fail with _Cannot Insert_ if the value to be added is one of those types as well.
+
+Note that the actual position of the new element is undefined, and that the array is not ordered.
+
+== Array insertion
+
+New elements can also be _inserted_ into an array.
+While _append_ will place a new item at the _end_ of an array and _prepend_ will place it at the beginning, _insert_ allows an element to be inserted at a specific _position_.
+The position is indicated by the last path component, which should be an array index.
+For example, to insert `"cruel"` as the second element in the array `["Hello", "world"]`, the code would look like:
+
+[source,bash]
+----
+$ cbc subdoc
+subdoc> upsert array ["Hello","world"]
+array                CAS=0x156a101efc4e0000
+
+subdoc> array-insert -p [1]="cruel" array
+array                CAS=0x156a1020d1130000
+0. Size=0, RC=0x00 Success (Not an error)
+
+subdoc> get array
+array                CAS=0x156a1020d1130000
+0. Size=25, RC=0x00 Success (Not an error)
+["Hello","cruel","world"]
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_ARRAY_INSERT;
+const char *path = "[1]";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "\"cruel\"";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "array";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+Note that the array must already exist and that the index must be valid (i.e.
+it must not point to an element which is out of bounds).
+
+== Counters and numeric fields
+
+Counter operations allow the manipulation of a _numeric_ value inside a document.
+These operations are logically similar to the _counter_ operation on an entire document:
+
+[source,bash]
+----
+$ cbc subdoc
+subdoc> counter -plogins=1 customer123
+customer123          CAS=0x156a1060e9a90000
+0. Size=1, RC=0x00 Success (Not an error)
+1
+
+subdoc> counter -plogins=1 customer123
+customer123          CAS=0x156a10640df50000
+0. Size=1, RC=0x00 Success (Not an error)
+2
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_COUNTER;
+const char *path = "logins";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "1";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+.output
+....
+customer123. CAS=0x156a1084524f0000
+0. Size=1, RC=LCB_SUCCESS (0x00)
+1
+....
+
+The _subdoc-counter_ operation peforms simple arithmetic against a numeric value, either incrementing or decrementing the existing value.
+
+[source,cpp]
+----
+static void player_subdoc_callback(lcb_t instance, int cbtype, const lcb_RESPBASE *rb)
+{
+    const lcb_RESPSUBDOC *resp = (const lcb_RESPSUBDOC *)rb;
+    lcb_SDENTRY cur;
+    size_t vii = 0;
+    if (rb->rc == LCB_SUCCESS) {
+        while (lcb_sdresult_next(resp, &cur, &vii)) {
+            if (cur.index == 0) {
+                printf("player %.*s now has %.*s gold remaining\n",
+                        (int)rb->nkey, (char *)rb->key,
+                        (int)cur.nvalue, (char *)cur.value);
+            }
+        }
+    }
+    (void)instance;
+}
+
+...
+
+lcb_install_callback3(instance, LCB_CALLBACK_SDMUTATE, player_subdoc_callback);
+
+...
+
+{
+    lcb_CMDSTORE cmd = {0};
+    cmd.datatype = LCB_DATATYPE_JSON;
+    const char *key = "player432";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    const char *value = "{\"gold\":1000}";
+    LCB_CMD_SET_VALUE(&cmd, value, strlen(value));
+    err = lcb_store3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule store: %s\n", lcb_strerror_short(err));
+    }
+}
+lcb_wait(instance); /* wait for store */
+{
+    lcb_SDSPEC spec = {0};
+    spec.sdcmd = LCB_SDCMD_COUNTER;
+    const char *path = "gold";
+    LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+    const char *value = "-150";
+    LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+    lcb_CMDSUBDOC cmd = {0};
+    const char *key = "player432";
+    LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+    cmd.nspecs = 1;
+    cmd.specs = &spec;
+    err = lcb_subdoc3(instance, NULL, &cmd);
+    if (err != LCB_SUCCESS) {
+        printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+    }
+}
+----
+.output
+....
+player432 Stored. CAS=0x156a10e1bae00000
+player player432 now has 850 gold remaining
+....
+
+The existing value for _subdoc-counter_ operations must be within range of a 64 bit signed integer.
+If the value does not exist, the _subdoc-counter_ operation will create it (and its parents, if _create-parents_ is enabled).
+
+Note that there are several differences between _subdoc-counter_ and the full-document _counter_ operations:
+
+[#ul_fp2_2yw_mv]
+* Sub-document counters have a range of -9223372036854775807 to 9223372036854775807 (i.e.
+`INT64_MIN` and `INT64_MAX`), whereas full-document counters have a range of 0 to 18446744073709551615 (`UINT64_MAX`)
+* Sub-document counter operations protect against overflow and underflow, returning an error if the operation would exceed the range.
+Full-document counters will use normal C semantics for overflow (in which the overflow value is carried over above 0), and will silently fail on underflow, setting the value to 0 instead.
+* Sub-document counter operations can operate on any numeric value within a document, while full-document counter operations require a specially formatted counter document with only the counter value.
+
+== Executing multiple operations
+
+Multiple sub-document operations can be executed at once on the same document, allowing you to retrieve or modify several sub-documents at once.
+When multiple operations are submitted within the context of a single _lookup-in_ or _mutate-in_ command, the server will execute all the operations with the same version of the document.
+
+NOTE: Unlike _batched operations_ which is simply a way of sending multiple individual operations efficiently on the network, multiple subdoc operations are formed into a single command packet, which is then executed atomically on the server.
+You can submit up to 16 operations at a time.
+
+When submitting multiple _mutation_ operations within a single _mutate-in_ command, those operations are considered to be part of a single transaction: if any of the mutation operations fail, the server will logically roll-back any other mutation operations performed within the _mutate-in_, even if those commands would have been successful had another command not failed.
+
+When submitting multiple _retrieval_ operations within a single _lookup-in_ command, the status of each command does not affect any other command.
+This means that it is possible for some retrieval operations to succeed and some others to fail.
+While their statuses are independent of each other, you should note that operations submitted within a single _lookup-in_ are all executed against the same _version_ of the document.
+
+[#subdoc-create-parents]
+== Creating parents
+
+Sub-document mutation operations such as _subdoc-upsert_ or _subdoc-insert_ will fail if the _immediate parent_ is not present in the document.
+Consider:
+
+[source,json]
+----
+{
+    "level_0": {
+        "level_1": {
+            "level_2": {
+                "level_3": {
+                    "some_field": "some_value"
+                }
+            }
+        }
+    }
+}
+----
+
+Looking at the `some_field` field (which is really `level_0.level_1.level_2.level_3.some_field`), its _immediate_ parent is `level_3`.
+If we were to attempt to insert another field, `level_0.level_1.level_2.level_3.another_field`, it would succeed because the immediate parent is present.
+However if we were to attempt to _subdoc-insert_ to `level_1.level_2.foo.bar` it would fail, because `level_1.level_2.foo` (which would be the immediate parent) does not exist.
+Attempting to perform such an operation would result in a Path Not Found error.
+
+By default the automatic creation of parents is disabled, as a simple typo in application code can result in a rather confusing document structure.
+Sometimes it is necessary to have the server create the hierarchy however.
+In this case, the _create-parents_ or _create-intermediates_ option may be used.
+
+[source,bash]
+----
+$ cbc subdoc
+subdoc> dict-upsert -i -plevel_0.level_1.foo.bar.phone={"num":"311-555-0101","ext":16} customer123
+customer123          CAS=0x156a112dd4060000
+0. Size=0, RC=0x00 Success (Not an error)
+
+subdoc> get  -p level_0 customer123
+customer123          CAS=0x156a112dd4060000
+0. Size=69, RC=0x00 Success (Not an error)
+{"level_1":{"foo":{"bar":{"phone":{"num":"311-555-0101","ext":16}}}}}
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.options = LCB_SDSPEC_F_MKINTERMEDIATES;
+spec.sdcmd = LCB_SDCMD_DICT_UPSERT;
+const char *path = "level_0.level_1.foo.bar.phone";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "{\"num\":\"311-555-0101\",\"ext\":16}";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+.output
+....
+customer123. CAS=0x156a1154e24b0000
+0. Size=0, RC=LCB_SUCCESS (0x00)
+....
+
+== CAS Semantics
+
+Subdoc mostly eliminates the need for tracking the xref:concurrent-mutations-cluster.adoc[CAS] value.
+Subdoc operations are atomic and therefore if two different threads access two different sub-documents then no conflict will arise.
+For example the following two blocks can execute concurrently without any risk of conflict:
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+const char *path = "purchases.complete";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "999";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+[source,cpp]
+----
+lcb_SDSPEC spec = {0};
+spec.sdcmd = LCB_SDCMD_ARRAY_ADD_LAST;
+const char *path = "purchases.abandoned";
+LCB_SDSPEC_SET_PATH(&spec, path, strlen(path));
+const char *value = "998";
+LCB_SDSPEC_SET_VALUE(&spec, value, strlen(value));
+
+lcb_CMDSUBDOC cmd = {0};
+const char *key = "customer123";
+LCB_CMD_SET_KEY(&cmd, key, strlen(key));
+cmd.nspecs = 1;
+cmd.specs = &spec;
+err = lcb_subdoc3(instance, NULL, &cmd);
+if (err != LCB_SUCCESS) {
+    printf("Unable to schedule subdoc: %s\n", lcb_strerror_short(err));
+}
+----
+
+Even when modifying the _same_ part of the document, operations will not necessarily conflict.
+For example, two concurrent _subdoc-array-append_ operations to the same array will both succeed, never overwriting the other.
+
+While CAS is no longer required to ensure document updates are preserved, it may still be needed to ensure document state remains consistent over multiple invocations of _mutate-in_: Sometimes it's important to ensure the entire document didn't change state since the last operation, such as in the case _subdoc-remove_ operations to ensure that the element being removed was not already replaced by something else.
+
+== Error handling
+
+Subdoc operations have their own set of errors.
+When programming with subdoc, be prepared for any of the full-document errors (such as _Document Not Found_) as well as special sub-document errors which are received when certain constraints are not satisfied.
+Some of the errors include:
+
+* *Path does not exist*: When retrieving a path, this means the path does not exist in the document.
+When inserting or upserting a path, this means the _immediate parent_ does not exist.
+* *Path already exists*: In the context of an _insert_, it means the given path already exists.
+In the context of _array-add-unique_, it means the given value already exists.
+* *Path mismatch*: This means the path may exist in the document, but that there is a type conflict between the path in the document and the path in the command.
+Consider the document:
++
+[source,json]
+----
+{ "tags": ["reno", "nevada", "west", "sierra"] }
+----
++
+The path `tags.sierra` is a mismatch, since `tags` is actually an array, while the path assumes it is a JSON object (dictionary).
+
+* *Document not JSON*: This means you are attempting to modify a binary document using sub-document operations.
+* *Invalid path*: This means the path is invalid for the command.
+Certain commands such as _subdoc-array-insert_ expect array elements as their final component, while others such as _subdoc-upsert_ and _subdoc-insert_ expect dictionary (object) keys.
+
+Because sub-document operations are executed using either _mutate-in_ or _replace-in_, if a command fails a top-level error is reported (_Multi Command Failure_), rather than an individual error code (e.g.
+_Path Not Found_).
+When receiving a top-level error code, you should traverse the results of the command to see which individual code failed.
+
+== Path syntax
+
+Path syntax largely follows N1QL conventions: A path is divided into components, with each component referencing a specific _level_ in a document hierarchy.
+Components are separated by dots (`.`) in the case where the element left of the dot is a dictionary, or by brackets (`[n]`) where the element left of the bracket is an array and `n` is the index within the array.
+
+As a special extension, you can indicate the _last element_ of an array by using an index of `-1`, for example to get the last element of the array in the document
+
+[source,json]
+----
+{"some":{"array":[1,2,3,4,5,6,7,8,9,0]}}
+----
+
+Use `some.array[-1]` as the path, which will return the element `0`.
+
+Each path component must conform as a JSON string, as if it were surrounded by quotes, and any character in the path which may invalidate it as a JSON string must be escaped by a backslash (`\`).
+In other words, the path component must match exactly the path inside the document itself.
+For example:
+
+[source,json]
+----
+{"literal\"quote": {"array": []}}
+----
+
+must be referenced as `literal\"quote.array`.
+
+If the path also has special path characters (i.e.
+a dot or brackets) it may be escaped using N1QL escapes.
+Considering the document
+
+[source,json]
+----
+{"literal[]bracket": {"literal.dot": true}}
+----
+
+A path such as `pass:c[`literal[]bracket`.`literal.dot`]`.
+You can use double-backticks (`pass:c[``]`) to reference a literal backtick.
+
+If you need to combine both JSON _and_ path-syntax literals you can do so by escaping the component from any JSON string characters (e.g.
+a quote or backslash) and then encapsulating it in backticks (`pass:c[`path`]`).
+Here is such an example in Python (for C/libcouchbase it would be trivial to write using your favourite JSON library):
+
+[source,python]
+----
+import json
+def escape_component(component):
+    component = json.dumps(component)[1:-1]
+    return '`' + component + '`'
+
+print escape_component("Hello!") # `Hello!`
+print escape_component("backtick[]") # `backtick[]`
+print escape_component("[\"mixed\\") # `[\"mixed\\`
+----
+
+NOTE: Currently, paths cannot exceed 1024 characters, and cannot be more than 32 levels deep.
+
+== XDCR
+
+XDCR only replicates full documents.
+Sub-documents are only replicated as part of the full document.


### PR DESCRIPTION
Hi @RichardSmedley, here are updates for libcouchbase subdocument code samples.

This is a copy of https://github.com/couchbase/docs-sdk-common/blob/93999ae63256ad10d7e8292729f499584737a1b1/modules/pages/partials/subdocument-operations.adoc with only examples updated

To get real diff, you can use this command:

    diff -U3 docs-sdk-common/modules/pages/partials/subdocument-operations.adoc
             docs-sdk-c/modules/ROOT/pages/subdocument-operations.adoc