### PR TITLE
DOC 4774 link fixes

### DIFF
--- a/modules/ROOT/pages/client-settings.adoc
+++ b/modules/ROOT/pages/client-settings.adoc
@@ -187,7 +187,7 @@ durability_interval=0.0001
 | [.opt]`lcb_ipv6_t` 
 | Controls whether hostname lookups should prefer IPv4 or IPv6. 
 Can be set to _allow_, _disable_ (the default), or _only_. 
-See xref:http://docs.couchbase.com/sdk-api/couchbase-c-client-2.10.3/group__lcb-cntl-settings.html#gaa63aaa3ed8ca23f4af41fa09df09d05d[Enumeration Type Documentation] for more info.
+See http://docs.couchbase.com/sdk-api/couchbase-c-client-2.10.3/group__lcb-cntl-settings.html#gaa63aaa3ed8ca23f4af41fa09df09d05d[Enumeration Type Documentation] for more info.
 
 
 | `randomize_nodes` (Boolean)

--- a/modules/ROOT/pages/client-settings.adoc
+++ b/modules/ROOT/pages/client-settings.adoc
@@ -187,7 +187,7 @@ durability_interval=0.0001
 | [.opt]`lcb_ipv6_t` 
 | Controls whether hostname lookups should prefer IPv4 or IPv6. 
 Can be set to _allow_, _disable_ (the default), or _only_. 
-See xref:http://docs.couchbase.com/sdk-api/couchbase-c-client-2.10.3/group__lcb-cntl-settings.html#gaa63aaa3ed8ca23f4af41fa09df09d05d[enums] for more info.
+See xref:http://docs.couchbase.com/sdk-api/couchbase-c-client-2.10.3/group__lcb-cntl-settings.html#gaa63aaa3ed8ca23f4af41fa09df09d05d[Enumeration Type Documentation] for more info.
 
 
 | `randomize_nodes` (Boolean)

--- a/modules/ROOT/pages/managing-connections.adoc
+++ b/modules/ROOT/pages/managing-connections.adoc
@@ -164,7 +164,7 @@ Note that if you pass more than one bootstrap host, DNS SRV lookup will not be a
 
 == IPv6
 IPv6 has been supported since Couchbase Data Platform 5.5 (Enterprise Edition), although LCB will use IPv4 by default. 
-IPv6 can be specified as allowed or preferred through the connection string `ipv6=allow`, or directly with the C SDK, since version xref:./relnotes-c-sdk.adoc#2-8-3-november-22-2017[2.8.3] of LCB -- see the xref:client-settings.adoc#settings-list[Client Settings] page.
+IPv6 can be specified as allowed or preferred through the connection string `ipv6=allow`, or directly with the C SDK, since version xref:relnotes-c-sdk.adoc#2-8-3-november-22-2017[2.8.3] of LCB -- see the xref:client-settings.adoc#settings-list[Client Settings] page.
 
 
 [#configcache]


### PR DESCRIPTION
Note anchor in release notes not correct in my local build, but matches the production build