### PR TITLE
temp fix C API ref link

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -127,7 +127,7 @@ rc = lcb_wait(instance);
 
 == Additional Resources
 
-The API reference is generated for each release and the latest can be found http://docs.couchbase.com/sdk-api/couchbase-c-client/[here].
+The API reference is generated for each release and the latest can be found https://docs.couchbase.com/sdk-api/couchbase-c-client-2.10.6/index.html[here].
 Older API references are linked from their respective sections in the xref:project-docs:sdk-release-notes.adoc[Release Notes].
 
 // xref:project-docs:migrating-sdk-code-to-3.n.adoc[The Migrating from SDK2 to 3 page] highlights the main differences to be aware of when migrating your code.


### PR DESCRIPTION
The previous link points to a missing page...
http://docs.couchbase.com/sdk-api/couchbase-c-client/
...which redirects the browser to the top of the docs
home at https://docs.couchbase.com/home/index.html

For now, choosing a real link that's for latest c api... 2.1.0.6 --
it's temporary as the real fix is probably fixing the URL of
http://docs.couchbase.com/sdk-api/couchbase-c-client
to not redirect to the docs home page.