### PR TITLE
Update distributed-acid-transactions-from-the-sdk.adoc

### DIFF
--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -8,6 +8,6 @@
 The C++ Transactions built upon the C SDK.
 
 
-Transactions are not available to interact directly with the C SDK, but our C++ Distributed ACID Transactions are built upon the C SDK -- more details on our xref:1.0@cxx-txns::distributed-acid-transactions-from-the-sdk.adoc[C++ Distributed Transactions] pages.
+Transactions are not available directly via the C SDK. Although our C++ Distributed ACID Transactions are built upon the C SDK it doesn't expose any C symbols explicitly. Applications built using C SDK and C++ Transactions can run in parallel without interfering with each other -- more details on our xref:1.0@cxx-txns::distributed-acid-transactions-from-the-sdk.adoc[C++ Distributed Transactions] pages.
 
 


### PR DESCRIPTION
Intention here is to say
 - C Transactions is not available
 - C++ Transaction is built on top of libcouchbase but doesnt expose any symbols such that a C SDK can consume it.
 -  Applications written using C SDK and C++ Transactions can run in parallel without interfering each other.

Please use your magical words here, the message is what that was needed to be passed along