### PR TITLE
Cleanup of #89 and #92

### DIFF
--- a/modules/devguide/examples/c/bulk-get.cc
+++ b/modules/devguide/examples/c/bulk-get.cc
@@ -68,6 +68,7 @@ main()
 
     lcb_install_callback(instance, LCB_CALLBACK_GET, reinterpret_cast<lcb_RESPCALLBACK>(get_callback));
 
+    // tag::batching
     // Make a list of keys to store initially
     std::vector<std::string> keys_to_get{ "foo", "bar", "baz" };
 
@@ -90,6 +91,7 @@ main()
     }
     lcb_sched_leave(instance);
     check(lcb_wait(instance, LCB_WAIT_DEFAULT), "wait for batch to complete");
+    // end::batching
 
     for (auto& result : results) {
         std::cout << result.key << ": ";

--- a/modules/devguide/examples/c/cas.cc
+++ b/modules/devguide/examples/c/cas.cc
@@ -164,6 +164,7 @@ main()
             }
 
             std::string new_value = add_item_to_list(result.value, item_value);
+            // tag::cas[]
             result = {}; // reset result object
             {
                 lcb_CMDSTORE* cmd = nullptr;
@@ -180,6 +181,7 @@ main()
                     std::cout << msg.str();
                 }
             }
+            // end::cas[]
 
             lcb_destroy(local_instance);
         });

--- a/modules/devguide/examples/c/counter.cc
+++ b/modules/devguide/examples/c/counter.cc
@@ -60,6 +60,7 @@ main()
     {
         // increment counter by 20 if it exists, and initialize with 100 otherwise
         lcb_CMDCOUNTER* cmd = nullptr;
+        // tag::atomic-counter[]
         check(lcb_cmdcounter_create(&cmd), "create COUNTER command");
         check(lcb_cmdcounter_key(cmd, document_id.c_str(), document_id.size()), "assign ID for COUNTER command");
         check(lcb_cmdcounter_initial(cmd, 100), "assign initial value for COUNTER command");
@@ -67,6 +68,7 @@ main()
         check(lcb_counter(instance, nullptr, cmd), "schedule COUNTER command");
         check(lcb_cmdcounter_destroy(cmd), "destroy COUNTER command");
         lcb_wait(instance, LCB_WAIT_DEFAULT);
+        // end::atomic-counter[]
     }
 
     {

--- a/modules/devguide/examples/c/expiration.cc
+++ b/modules/devguide/examples/c/expiration.cc
@@ -28,6 +28,7 @@ static void
 store_key(lcb_INSTANCE* instance, const std::string& key, const std::string& value, std::chrono::seconds expiry = {})
 {
     lcb_CMDSTORE* cmd = nullptr;
+    // tag::expiration[]
     check(lcb_cmdstore_create(&cmd, LCB_STORE_UPSERT), "create UPSERT command");
     check(lcb_cmdstore_key(cmd, key.c_str(), key.size()), "assign ID for UPSERT command");
     check(lcb_cmdstore_value(cmd, value.c_str(), value.size()), "assign value for UPSERT command");
@@ -35,6 +36,7 @@ store_key(lcb_INSTANCE* instance, const std::string& key, const std::string& val
     check(lcb_store(instance, nullptr, cmd), "schedule UPSERT command");
     check(lcb_cmdstore_destroy(cmd), "destroy UPSERT command");
     lcb_wait(instance, LCB_WAIT_DEFAULT);
+    // end::expiration[]
 }
 
 static void

--- a/modules/devguide/examples/c/query-criteria.cc
+++ b/modules/devguide/examples/c/query-criteria.cc
@@ -79,6 +79,7 @@ main(int, char**)
 
     Rows result{};
 
+    // tag::query[]
     std::string statement = "SELECT airportname, city, country FROM `" + bucket_name + R"(` WHERE type="airport" AND city="New York")";
 
     lcb_CMDQUERY* cmd = nullptr;
@@ -88,6 +89,7 @@ main(int, char**)
     check(lcb_query(instance, &result, cmd), "schedule QUERY command");
     check(lcb_cmdquery_destroy(cmd), "destroy QUERY command");
     lcb_wait(instance, LCB_WAIT_DEFAULT);
+    // end::query[]
 
     std::cout << "Query returned " << result.rows.size() << " rows\n";
     for (const auto& row : result.rows) {

--- a/modules/devguide/examples/c/query-placeholders.cc
+++ b/modules/devguide/examples/c/query-placeholders.cc
@@ -60,6 +60,7 @@ query_city(lcb_INSTANCE* instance, const std::string& bucket_name, const std::st
 {
     Rows result{};
 
+    // tag::placeholder[]
     std::string statement = "SELECT airportname, city, country FROM `" + bucket_name + R"(` WHERE type="airport" AND city=$1)";
 
     lcb_CMDQUERY* cmd = nullptr;
@@ -73,6 +74,7 @@ query_city(lcb_INSTANCE* instance, const std::string& bucket_name, const std::st
     check(lcb_query(instance, &result, cmd), "schedule QUERY command");
     check(lcb_cmdquery_destroy(cmd), "destroy QUERY command");
     lcb_wait(instance, LCB_WAIT_DEFAULT);
+    // end::placeholder[]
 
     std::cout << "\n--- Query returned " << result.rows.size() << " rows for " << city << std::endl;
     for (const auto& row : result.rows) {

--- a/modules/devguide/examples/c/subdoc-retrieving.cc
+++ b/modules/devguide/examples/c/subdoc-retrieving.cc
@@ -105,8 +105,12 @@ main(int, char**)
         };
 
         check(lcb_subdocspecs_get(specs, 0, 0, paths[0].c_str(), paths[0].size()), "create SUBDOC-GET operation");
+        // tag::sub-doc-retrieve[]
         check(lcb_subdocspecs_get(specs, 1, 0, paths[1].c_str(), paths[1].size()), "create SUBDOC-GET operation");
+        // end::sub-doc-retrieve[]
+        // tag::sub-doc-exists[]
         check(lcb_subdocspecs_exists(specs, 2, 0, paths[2].c_str(), paths[2].size()), "create SUBDOC-EXISTS operation");
+        // end::sub-doc-exists[]
 
         lcb_CMDSUBDOC* cmd = nullptr;
         check(lcb_cmdsubdoc_create(&cmd), "create SUBDOC command");

--- a/modules/devguide/examples/c/subdoc-updating.cc
+++ b/modules/devguide/examples/c/subdoc-updating.cc
@@ -89,6 +89,7 @@ main()
         std::string value{ R"({"name":"john", "array":[1,2,3,4], "email":"john@example.com"})" };
         std::cout << "Initial document is: " << value << "\n";
 
+        // tag::sub-doc-mutate[]
         lcb_CMDSTORE* cmd = nullptr;
         check(lcb_cmdstore_create(&cmd, LCB_STORE_UPSERT), "create UPSERT command");
         check(lcb_cmdstore_key(cmd, key.c_str(), key.size()), "assign ID for UPSERT command");
@@ -96,6 +97,7 @@ main()
         check(lcb_store(instance, nullptr, cmd), "schedule UPSERT command");
         check(lcb_cmdstore_destroy(cmd), "destroy UPSERT command");
         lcb_wait(instance, LCB_WAIT_DEFAULT);
+        // end::sub-doc-mutate[]
     }
 
     lcb_install_callback(instance, LCB_CALLBACK_SDMUTATE, reinterpret_cast<lcb_RESPCALLBACK>(sdmutate_callback));
@@ -106,22 +108,23 @@ main()
         lcb_SUBDOCSPECS* specs = nullptr;
         check(lcb_subdocspecs_create(&specs, 3), "create SUBDOC operations container");
 
+        // tag::path[]
         std::vector<std::string> paths{
             "array",
             "array[0]",
             "description",
         };
-
+        // tag::array-insert[]
         std::string value_to_add{ "42" };
         check(lcb_subdocspecs_array_add_last(specs, 0, 0, paths[0].c_str(), paths[0].size(), value_to_add.c_str(), value_to_add.size()),
               "create ARRAY_ADD_LAST operation");
-
+        // end::array-insert[]
         check(lcb_subdocspecs_counter(specs, 1, 0, paths[1].c_str(), paths[1].size(), 99), "create COUNTER operation");
 
         std::string value_to_upsert{ R"("just a dev")" };
         check(lcb_subdocspecs_dict_upsert(specs, 2, 0, paths[2].c_str(), paths[2].size(), value_to_upsert.c_str(), value_to_upsert.size()),
               "create DICT_UPSERT operation");
-
+        // end::path[]
         lcb_CMDSUBDOC* cmd = nullptr;
         check(lcb_cmdsubdoc_create(&cmd), "create SUBDOC command");
         check(lcb_cmdsubdoc_key(cmd, key.c_str(), key.size()), "assign ID to SUBDOC command");

--- a/modules/howtos/examples/.clang-format
+++ b/modules/howtos/examples/.clang-format
@@ -1,0 +1,11 @@
+# -*- mode: yaml; -*-
+
+BasedOnStyle: LLVM
+IndentWidth: 4
+BreakBeforeBraces: Linux
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: Empty
+SortIncludes: false
+IndentCaseLabels: true
+SpacesInAngles: false
+AlwaysBreakTemplateDeclarations: Yes

--- a/modules/howtos/examples/.gitignore
+++ b/modules/howtos/examples/.gitignore
@@ -1,0 +1,3 @@
+/cmake-build-*
+/.idea
+/build

--- a/modules/howtos/examples/CMakeLists.txt
+++ b/modules/howtos/examples/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.5.1)
+project(devguide LANGUAGES CXX C)
+
+include(cmake/PreventInSourceBuilds.cmake)
+include(cmake/StandardProjectSettings.cmake)
+
+add_library(project_options INTERFACE)
+target_compile_features(project_options INTERFACE cxx_std_11)
+add_library(project_warnings INTERFACE)
+
+include(cmake/Cache.cmake)
+
+include(cmake/CompilerWarnings.cmake)
+set_project_warnings(project_warnings)
+
+include(cmake/Sanitizers.cmake)
+enable_sanitizers(project_options)
+
+include(FindThreads)
+
+add_library(cJSON cJSON.c)
+
+macro(add_example name)
+    add_executable(${name} ${name}.cc)
+    target_link_libraries(${name} project_options project_warnings couchbase)
+endmacro()
+
+add_example(analytics)
+target_link_libraries(analytics cJSON)
+
+add_example(array-append-prepend)
+add_example(atomic-counters)
+add_example(bulk-get)
+add_example(durability)
+add_example(expiration)
+add_example(insert-upsert)
+add_example(query-placeholders)
+add_example(query-criteria)
+add_example(subdoc-retrieving)
+add_example(subdoc-updating)
+add_example(views)
+
+if (Threads_FOUND)
+    add_example(cas)
+    target_link_libraries(cas Threads::Threads)
+endif()

--- a/modules/howtos/examples/README.md
+++ b/modules/howtos/examples/README.md
@@ -1,0 +1,9 @@
+This directory contains several examples, that are used by the documentation site.
+
+To compile them, navigate to this directory (`modules/howtos/examples/`), make sure you have libcouchbase library
+and headers installed in the system, as well as C++ compiler and `cmake` build tool. Then run the following sequence:
+
+    mkdir build
+    cd build
+    cmake ..
+    cmake --build .

--- a/modules/howtos/examples/analytics.cc
+++ b/modules/howtos/examples/analytics.cc
@@ -1,0 +1,161 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *     Copyright 2018-2020 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <string>
+#include <iostream>
+#include <cstdlib>
+#include <cstring>
+
+#include <libcouchbase/couchbase.h>
+
+#include "cJSON.h"
+
+static void fail(lcb_STATUS err, const char *msg)
+{
+    std::cerr << "[ERROR] " << msg << ": " << lcb_strerror_short(err) << "\n";
+    exit(EXIT_FAILURE);
+}
+
+static void check(lcb_STATUS err, const char *msg)
+{
+    if (err != LCB_SUCCESS) {
+        fail(err, msg);
+    }
+}
+
+static void row_callback(lcb_INSTANCE *instance, int, const lcb_RESPANALYTICS *resp)
+{
+    // tag::result[]
+    int *idx;
+    const char *row;
+    size_t nrow;
+    lcb_STATUS rc = lcb_respanalytics_status(resp);
+
+    lcb_respanalytics_cookie(resp, reinterpret_cast<void **>(&idx));
+    lcb_respanalytics_row(resp, &row, &nrow);
+    if (rc != LCB_SUCCESS) {
+        const lcb_RESPHTTP *http;
+        std::cout << lcb_strerror_short(rc);
+        lcb_respanalytics_http_response(resp, &http);
+        // end::result[]
+        if (http) {
+            uint16_t status;
+            lcb_resphttp_http_status(http, &status);
+            std::cout << ", HTTP status: " << status;
+        }
+        printf("\n");
+        if (nrow) {
+            cJSON *json;
+            char *data = new char[nrow + 1];
+            memcpy(data, row, nrow); /* copy to ensure trailing zero */
+            json = cJSON_Parse(data);
+            if (json && json->type == cJSON_Object) {
+                cJSON *errors = cJSON_GetObjectItem(json, "errors");
+                if (errors && errors->type == cJSON_Array) {
+                    int ii, nerrors = cJSON_GetArraySize(errors);
+                    for (ii = 0; ii < nerrors; ii++) {
+                        cJSON *err = cJSON_GetArrayItem(errors, ii);
+                        if (err && err->type == cJSON_Object) {
+                            cJSON *code, *msg;
+                            code = cJSON_GetObjectItem(err, "code");
+                            msg = cJSON_GetObjectItem(err, "msg");
+                            if (code && code->type == cJSON_Number && msg && msg->type == cJSON_String) {
+                                printf(
+                                    "\x1b[1mcode\x1b[0m: \x1b[31m%d\x1b[0m, \x1b[1mmessage\x1b[0m: \x1b[31m%s\x1b[0m\n",
+                                    code->valueint, msg->valuestring);
+                            }
+                        }
+                    }
+                }
+            }
+            delete[] data;
+        }
+    }
+
+    if (lcb_respanalytics_is_final(resp)) {
+        std::cout << "META: ";
+        printf("\x1b[1mMETA:\x1b[0m ");
+    } else {
+        std::cout << (*idx)++ << " ";
+    }
+    std::cout << std::string(row, nrow) << "\n";
+    if (lcb_respanalytics_is_final(resp)) {
+        std::cout << "\n";
+    }
+
+    lcb_DEFERRED_HANDLE *handle = nullptr;
+    lcb_respanalytics_deferred_handle_extract(resp, &handle);
+    if (handle) {
+        const char *status;
+        size_t status_len;
+        lcb_deferred_handle_status(handle, &status, &status_len);
+        std::cout << "DEFERRED: " << std::string(status, status_len) << "\n";
+        lcb_deferred_handle_callback(handle, row_callback);
+        check(lcb_deferred_handle_poll(instance, idx, handle), "poll deferred query status");
+        lcb_deferred_handle_destroy(handle);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    lcb_INSTANCE *instance;
+
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " couchbase://host/beer-sample [ password [ username ] ]\n";
+        exit(EXIT_FAILURE);
+    }
+
+    {
+        lcb_CREATEOPTS *create_options = nullptr;
+        lcb_createopts_create(&create_options, LCB_TYPE_BUCKET);
+        lcb_createopts_connstr(create_options, argv[1], strlen(argv[1]));
+        if (argc > 3) {
+            lcb_createopts_credentials(create_options, argv[3], strlen(argv[3]), argv[2], strlen(argv[2]));
+        }
+        check(lcb_create(&instance, create_options), "create couchbase handle");
+        lcb_createopts_destroy(create_options);
+        check(lcb_connect(instance), "schedule connection");
+        lcb_wait(instance, LCB_WAIT_DEFAULT);
+        check(lcb_get_bootstrap_status(instance), "bootstrap from cluster");
+        {
+            char *bucket = nullptr;
+            check(lcb_cntl(instance, LCB_CNTL_GET, LCB_CNTL_BUCKETNAME, &bucket), "get bucket name");
+            if (strcmp(bucket, "beer-sample") != 0) {
+                fail(LCB_ERR_INVALID_ARGUMENT, "expected bucket to be \"beer-sample\"");
+            }
+        }
+    }
+
+    {
+        // tag::analytics[]
+        const char *stmt = "SELECT * FROM breweries LIMIT 2";
+        lcb_CMDANALYTICS *cmd;
+        int idx = 0;
+        lcb_cmdanalytics_create(&cmd);
+        lcb_cmdanalytics_callback(cmd, row_callback);
+        lcb_cmdanalytics_statement(cmd, stmt, strlen(stmt));
+        lcb_cmdanalytics_deferred(cmd, 1);
+        check(lcb_analytics(instance, &idx, cmd), "schedule analytics query");
+        std::cout << "----> " << stmt << "\n";
+        lcb_cmdanalytics_destroy(cmd);
+        lcb_wait(instance, LCB_WAIT_DEFAULT);
+        // end::analytics[]
+    }
+    /* Now that we're all done, close down the connection handle */
+    lcb_destroy(instance);
+    return 0;
+}

--- a/modules/howtos/examples/array-append-prepend.cc
+++ b/modules/howtos/examples/array-append-prepend.cc
@@ -1,0 +1,266 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *     Copyright 2015-2020 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <string>
+#include <iostream>
+#include <cstring>
+
+#include <libcouchbase/couchbase.h>
+
+static void check(lcb_STATUS err)
+{
+    if (err != LCB_SUCCESS) {
+        std::cerr << "ERROR: " << lcb_strerror_short(err) << "\n";
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void get_callback(lcb_INSTANCE *, int cbtype, const lcb_RESPGET *resp)
+{
+    std::cerr << "Got callback for " << lcb_strcbtype(cbtype) << "\n";
+
+    lcb_STATUS rc = lcb_respget_status(resp);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Operation failed: " << lcb_strerror_short(rc) << "\n";
+        return;
+    }
+
+    const char *value;
+    size_t nvalue;
+    lcb_respget_value(resp, &value, &nvalue);
+    std::cerr << "Value: " << std::string(value, nvalue) << "\n";
+}
+
+static void store_callback(lcb_INSTANCE *, int cbtype, const lcb_RESPSTORE *resp)
+{
+    std::cerr << "Got callback for " << lcb_strcbtype(cbtype) << "\n";
+
+    lcb_STATUS rc = lcb_respstore_status(resp);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Operation failed: " << lcb_strerror_short(rc) << "\n";
+        return;
+    }
+
+    std::cerr << "OK\n";
+}
+
+static void subdoc_callback(lcb_INSTANCE *, int cbtype, const lcb_RESPSUBDOC *resp)
+{
+    lcb_STATUS rc = lcb_respsubdoc_status(resp);
+
+    std::cerr << "Got callback for " << lcb_strcbtype(cbtype) << "\n";
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Operation failed: " << lcb_strerror_short(rc) << "\n";
+        return;
+    }
+
+    if (lcb_respsubdoc_result_size(resp) > 0) {
+        const char *value;
+        size_t nvalue;
+        lcb_respsubdoc_result_value(resp, 0, &value, &nvalue);
+        rc = lcb_respsubdoc_result_status(resp, 0);
+        std::cerr << "Status: " << lcb_strerror_short(rc) << ". Value: " << std::string(value, nvalue) << "\n";
+    } else {
+        std::cerr << "No result!\n";
+    }
+}
+
+// Function to issue an lcb_get() (and print the state of the document)
+static void demoKey(lcb_INSTANCE *instance, const char *key)
+{
+    std::cout << "Retrieving '" << key << "'\n";
+    std::cout << "====\n";
+    lcb_CMDGET *gcmd;
+    lcb_cmdget_create(&gcmd);
+    lcb_cmdget_key(gcmd, key, strlen(key));
+    lcb_STATUS rc = lcb_get(instance, nullptr, gcmd);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Failed to schedule GET operation: " << lcb_strerror_short(rc) << "\n";
+        return;
+    }
+    lcb_cmdget_destroy(gcmd);
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+    std::cout << "====\n\n";
+}
+
+// cluster_run mode
+#define DEFAULT_CONNSTR "couchbase://localhost"
+int main(int argc, char **argv)
+{
+    lcb_CREATEOPTS *crst = nullptr;
+    const char *connstr, *username, *password;
+
+    if (argc > 1) {
+        connstr = argv[1];
+    } else {
+        connstr = DEFAULT_CONNSTR;
+    }
+    if (argc > 2) {
+        username = argv[2];
+    } else {
+        username = "Administrator";
+    }
+    if (argc > 3) {
+        password = argv[3];
+    } else {
+        password = "password";
+    }
+    lcb_createopts_create(&crst, LCB_TYPE_BUCKET);
+    lcb_createopts_connstr(crst, connstr, strlen(connstr));
+    lcb_createopts_credentials(crst, username, strlen(username), password, strlen(password));
+
+    lcb_INSTANCE *instance;
+    check(lcb_create(&instance, crst));
+    lcb_createopts_destroy(crst);
+
+    check(lcb_connect(instance));
+
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+
+    check(lcb_get_bootstrap_status(instance));
+
+    lcb_install_callback(instance, LCB_CALLBACK_STORE, reinterpret_cast<lcb_RESPCALLBACK>(store_callback));
+    lcb_install_callback(instance, LCB_CALLBACK_GET, reinterpret_cast<lcb_RESPCALLBACK>(get_callback));
+    lcb_install_callback(instance, LCB_CALLBACK_SDLOOKUP, reinterpret_cast<lcb_RESPCALLBACK>(subdoc_callback));
+    lcb_install_callback(instance, LCB_CALLBACK_SDMUTATE, reinterpret_cast<lcb_RESPCALLBACK>(subdoc_callback));
+
+    // Store the initial document. Subdocument operations cannot create
+    // documents
+    std::cout << "Storing the initial item..\n";
+    // Store an item
+    lcb_CMDSTORE *scmd;
+    lcb_cmdstore_create(&scmd, LCB_STORE_UPSERT);
+    lcb_cmdstore_key(scmd, "key", 3);
+    const char *initval = R"({"hello":"world"})";
+    lcb_cmdstore_value(scmd, initval, strlen(initval));
+    lcb_STATUS rc = lcb_store(instance, nullptr, scmd);
+    lcb_cmdstore_destroy(scmd);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Failed to schedule store operation: " << lcb_strerror_short(rc) << "\n";
+        return 1;
+    }
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+
+    lcb_CMDSUBDOC *cmd;
+    lcb_SUBDOCSPECS *ops;
+
+    lcb_cmdsubdoc_create(&cmd);
+    lcb_cmdsubdoc_key(cmd, "key", 3);
+
+    /**
+     * Retrieve a single item from a document
+     */
+    std::cout << "Getting the 'hello' path from the document\n";
+    lcb_subdocspecs_create(&ops, 1);
+    lcb_subdocspecs_get(ops, 0, 0, "hello", 5);
+    lcb_cmdsubdoc_specs(cmd, ops);
+    rc = lcb_subdoc(instance, nullptr, cmd);
+    lcb_subdocspecs_destroy(ops);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Failed to schedule subdocument operation: " << lcb_strerror_short(rc) << "\n";
+        return 1;
+    }
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+
+    /**
+     * Set a dictionary/object field
+     */
+    std::cout << "Adding new 'goodbye' path to document\n";
+    lcb_subdocspecs_create(&ops, 1);
+    lcb_subdocspecs_dict_upsert(ops, 0, 0, "goodbye", 7, "\"hello\"", 7);
+    lcb_cmdsubdoc_specs(cmd, ops);
+    rc = lcb_subdoc(instance, nullptr, cmd);
+    lcb_subdocspecs_destroy(ops);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Failed to schedule subdocument operation: " << lcb_strerror_short(rc) << "\n";
+        return 1;
+    }
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+    demoKey(instance, "key");
+
+    /**
+     * Add new element to end of an array
+     */
+    // Options can also be used
+    // tag::array-append[]
+    std::cout << "Appending element to array (array might be missing)\n";
+    lcb_subdocspecs_create(&ops, 1);
+    // Create the array if it doesn't exist. This option can be used with
+    // other commands as well..
+    lcb_subdocspecs_array_add_last(ops, 0, LCB_SUBDOCSPECS_F_MKINTERMEDIATES, "array", 5, "1", 1);
+    lcb_cmdsubdoc_specs(cmd, ops);
+    rc = lcb_subdoc(instance, nullptr, cmd);
+    lcb_subdocspecs_destroy(ops);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Failed to schedule subdocument operation: " << lcb_strerror_short(rc) << "\n";
+        return 1;
+    }
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+    demoKey(instance, "key");
+    // end::array-append[]
+    /**
+     * Add element to the beginning of an array
+     */
+    // tag::array-prepend[]
+    std::cout << "Prepending element to array (array must exist)\n";
+    lcb_subdocspecs_create(&ops, 1);
+    lcb_subdocspecs_array_add_first(ops, 0, 0, "array", 5, "1", 1);
+    lcb_cmdsubdoc_specs(cmd, ops);
+    rc = lcb_subdoc(instance, nullptr, cmd);
+    lcb_subdocspecs_destroy(ops);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Failed to schedule subdocument operation: " << lcb_strerror_short(rc) << "\n";
+        return 1;
+    }
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+    demoKey(instance, "key");
+    // end::array-prepend[]
+    /**
+     * Add unique element to the beginning of an array
+     */
+    // tag::array-unique[]
+    lcb_subdocspecs_create(&ops, 1);
+    lcb_subdocspecs_array_add_unique(ops, 0, LCB_SUBDOCSPECS_F_MKINTERMEDIATES, "a", strlen("a"), "1", strlen("1"));
+    lcb_cmdsubdoc_specs(cmd, ops);
+    rc = lcb_subdoc(instance, nullptr, cmd);
+    lcb_subdocspecs_destroy(ops);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Failed to schedule subdocument operation: " << lcb_strerror_short(rc) << "\n";
+        return 1;
+    }
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+    demoKey(instance, "key");
+    // end::array-unique[]
+
+    /**
+     * Get the first element back..
+     */
+    std::cout << "Getting first array element...\n";
+    lcb_subdocspecs_create(&ops, 1);
+    lcb_subdocspecs_get(ops, 0, 0, "array[0]", 8);
+    lcb_cmdsubdoc_specs(cmd, ops);
+    rc = lcb_subdoc(instance, nullptr, cmd);
+    lcb_subdocspecs_destroy(ops);
+    if (rc != LCB_SUCCESS) {
+        std::cerr << "Failed to schedule subdocument operation: " << lcb_strerror_short(rc) << "\n";
+        return 1;
+    }
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+
+    lcb_destroy(instance);
+    return 0;
+}

--- a/modules/howtos/examples/atomic-counters.cc
+++ b/modules/howtos/examples/atomic-counters.cc
@@ -1,0 +1,1 @@
+../../devguide/examples/c/counter.cc

--- a/modules/howtos/examples/bulk-get.cc
+++ b/modules/howtos/examples/bulk-get.cc
@@ -1,0 +1,1 @@
+../../devguide/examples/c/bulk-get.cc

--- a/modules/howtos/examples/cJSON.c
+++ b/modules/howtos/examples/cJSON.c
@@ -1,0 +1,1 @@
+../../devguide/examples/c/bincoding/cJSON.c

--- a/modules/howtos/examples/cJSON.h
+++ b/modules/howtos/examples/cJSON.h
@@ -1,0 +1,1 @@
+../../devguide/examples/c/bincoding/cJSON.h

--- a/modules/howtos/examples/cas.cc
+++ b/modules/howtos/examples/cas.cc
@@ -1,0 +1,1 @@
+../../devguide/examples/c/cas.cc

--- a/modules/howtos/examples/cmake/Cache.cmake
+++ b/modules/howtos/examples/cmake/Cache.cmake
@@ -1,0 +1,29 @@
+option(ENABLE_CACHE "Enable cache if available" ON)
+if(NOT ENABLE_CACHE)
+  return()
+endif()
+
+set(CACHE_OPTION
+    "ccache"
+    CACHE STRING "Compiler cache to be used")
+set(CACHE_OPTION_VALUES "ccache" "sccache")
+set_property(CACHE CACHE_OPTION PROPERTY STRINGS ${CACHE_OPTION_VALUES})
+list(
+  FIND
+  CACHE_OPTION_VALUES
+  ${CACHE_OPTION}
+  CACHE_OPTION_INDEX)
+
+if(${CACHE_OPTION_INDEX} EQUAL -1)
+  message(
+    STATUS
+      "Using custom compiler cache system: '${CACHE_OPTION}', explicitly supported entries are ${CACHE_OPTION_VALUES}")
+endif()
+
+find_program(CACHE_BINARY ${CACHE_OPTION})
+if(CACHE_BINARY)
+  message(STATUS "${CACHE_OPTION} found and enabled")
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CACHE_BINARY})
+else()
+  message(WARNING "${CACHE_OPTION} is enabled but was not found. Not using it")
+endif()

--- a/modules/howtos/examples/cmake/CompilerWarnings.cmake
+++ b/modules/howtos/examples/cmake/CompilerWarnings.cmake
@@ -1,0 +1,83 @@
+# from here:
+#
+# https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
+
+function(set_project_warnings project_name)
+  option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
+
+  set(MSVC_WARNINGS
+      /W4 # Baseline reasonable warnings
+      /w14242 # 'identifier': conversion from 'type1' to 'type1', possible loss of data
+      /w14254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+      /w14263 # 'function': member function does not override any base class virtual member function
+      /w14265 # 'classname': class has virtual functions, but destructor is not virtual instances of this class may not
+              # be destructed correctly
+      /w14287 # 'operator': unsigned/negative constant mismatch
+      /we4289 # nonstandard extension used: 'variable': loop control variable declared in the for-loop is used outside
+              # the for-loop scope
+      /w14296 # 'operator': expression is always 'boolean_value'
+      /w14311 # 'variable': pointer truncation from 'type1' to 'type2'
+      /w14545 # expression before comma evaluates to a function which is missing an argument list
+      /w14546 # function call before comma missing argument list
+      /w14547 # 'operator': operator before comma has no effect; expected operator with side-effect
+      /w14549 # 'operator': operator before comma has no effect; did you intend 'operator'?
+      /w14555 # expression has no effect; expected expression with side- effect
+      /w14619 # pragma warning: there is no warning number 'number'
+      /w14640 # Enable warning on thread un-safe static member initialization
+      /w14826 # Conversion from 'type1' to 'type_2' is sign-extended. This may cause unexpected runtime behavior.
+      /w14905 # wide string literal cast to 'LPSTR'
+      /w14906 # string literal cast to 'LPWSTR'
+      /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
+      /permissive- # standards conformance mode for MSVC compiler.
+  )
+
+  set(CLANG_WARNINGS
+      -Wall
+      -Wextra # reasonable and standard
+      -Wshadow # warn the user if a variable declaration shadows one from a parent context
+      -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor. This helps
+                         # catch hard to track down memory errors
+      -Wold-style-cast # warn for c-style casts
+      -Wcast-align # warn for potential performance problem casts
+      -Wunused # warn on anything being unused
+      -Woverloaded-virtual # warn if you overload (not override) a virtual function
+      -Wpedantic # warn if non-standard C++ is used
+      -Wconversion # warn on type conversions that may lose data
+      -Wsign-conversion # warn on sign conversions
+      -Wnull-dereference # warn if a null dereference is detected
+      -Wdouble-promotion # warn if float is implicit promoted to double
+      -Wformat=2 # warn on security issues around functions that format output (ie printf)
+
+      # TODO: make it local to ext/couchbase/couchbase.cxx
+      -Wno-unknown-warning-option
+      -Wno-gnu-statement-expression
+      -Wno-compound-token-split-by-macro
+  )
+
+  if(WARNINGS_AS_ERRORS)
+    set(CLANG_WARNINGS ${CLANG_WARNINGS} -Werror)
+    set(MSVC_WARNINGS ${MSVC_WARNINGS} /WX)
+  endif()
+
+  set(GCC_WARNINGS
+      ${CLANG_WARNINGS}
+      -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
+      -Wduplicated-cond # warn if if / else chain has duplicated conditions
+      -Wduplicated-branches # warn if if / else branches have duplicated code
+      -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
+      -Wuseless-cast # warn if you perform a cast to the same type
+  )
+
+  if(MSVC)
+    set(PROJECT_WARNINGS ${MSVC_WARNINGS})
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    set(PROJECT_WARNINGS ${CLANG_WARNINGS})
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(PROJECT_WARNINGS ${GCC_WARNINGS})
+  else()
+    message(AUTHOR_WARNING "No compiler warnings set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
+  endif()
+
+  target_compile_options(${project_name} INTERFACE ${PROJECT_WARNINGS})
+
+endfunction()

--- a/modules/howtos/examples/cmake/PreventInSourceBuilds.cmake
+++ b/modules/howtos/examples/cmake/PreventInSourceBuilds.cmake
@@ -1,0 +1,18 @@
+#
+# This function will prevent in-source builds
+function(AssureOutOfSourceBuilds)
+  # make sure the user doesn't play dirty with symlinks
+  get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+  get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+
+  # disallow in-source builds
+  if("${srcdir}" STREQUAL "${bindir}")
+    message("######################################################")
+    message("Warning: in-source builds are disabled")
+    message("Please create a separate build directory and run cmake from there")
+    message("######################################################")
+    message(FATAL_ERROR "Quitting configuration")
+  endif()
+endfunction()
+
+assureoutofsourcebuilds()

--- a/modules/howtos/examples/cmake/Sanitizers.cmake
+++ b/modules/howtos/examples/cmake/Sanitizers.cmake
@@ -1,0 +1,66 @@
+function(enable_sanitizers project_name)
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang" FALSE)
+
+    if(ENABLE_COVERAGE)
+      target_compile_options(${project_name} INTERFACE --coverage -O0 -g)
+      target_link_libraries(${project_name} INTERFACE --coverage)
+    endif()
+
+    set(SANITIZERS "")
+
+    option(ENABLE_SANITIZER_ADDRESS "Enable address sanitizer" FALSE)
+    if(ENABLE_SANITIZER_ADDRESS)
+      list(APPEND SANITIZERS "address")
+    endif()
+
+    option(ENABLE_SANITIZER_LEAK "Enable leak sanitizer" FALSE)
+    if(ENABLE_SANITIZER_LEAK)
+      list(APPEND SANITIZERS "leak")
+    endif()
+
+    option(ENABLE_SANITIZER_UNDEFINED_BEHAVIOUR "Enable undefined behaviour sanitizer" FALSE)
+    if(ENABLE_SANITIZER_UNDEFINED_BEHAVIOUR)
+      list(APPEND SANITIZERS "undefined")
+    endif()
+
+    option(ENABLE_SANITIZER_THREAD "Enable thread sanitizer" FALSE)
+    if(ENABLE_SANITIZER_THREAD)
+      if("address" IN_LIST SANITIZERS OR "leak" IN_LIST SANITIZERS)
+        message(WARNING "Thread sanitizer does not work with Address and Leak sanitizer enabled")
+      else()
+        list(APPEND SANITIZERS "thread")
+      endif()
+    endif()
+
+    option(ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" FALSE)
+    if(ENABLE_SANITIZER_MEMORY AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+      if("address" IN_LIST SANITIZERS
+         OR "thread" IN_LIST SANITIZERS
+         OR "leak" IN_LIST SANITIZERS)
+        message(WARNING "Memory sanitizer does not work with Address, Thread and Leak sanitizer enabled")
+      else()
+        list(APPEND SANITIZERS "memory")
+      endif()
+    endif()
+
+    list(
+      JOIN
+      SANITIZERS
+      ","
+      LIST_OF_SANITIZERS)
+
+  endif()
+
+  if(LIST_OF_SANITIZERS)
+    if(NOT
+       "${LIST_OF_SANITIZERS}"
+       STREQUAL
+       "")
+      target_compile_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
+      target_link_libraries(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
+    endif()
+  endif()
+
+endfunction()

--- a/modules/howtos/examples/cmake/StandardProjectSettings.cmake
+++ b/modules/howtos/examples/cmake/StandardProjectSettings.cmake
@@ -1,0 +1,28 @@
+set(CMAKE_CXX_STANDARD 11)
+
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
+  set(CMAKE_BUILD_TYPE
+      RelWithDebInfo
+      CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui, ccmake
+  set_property(
+    CACHE CMAKE_BUILD_TYPE
+    PROPERTY STRINGS
+             "Debug"
+             "Release"
+             "MinSizeRel"
+             "RelWithDebInfo")
+endif()
+
+# Generate compile_commands.json to make it easier to work with clang based tools
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+  add_compile_options(-fcolor-diagnostics)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  add_compile_options(-fdiagnostics-color=always)
+else()
+  message(STATUS "No colored compiler diagnostic set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
+endif()

--- a/modules/howtos/examples/durability.cc
+++ b/modules/howtos/examples/durability.cc
@@ -1,0 +1,1 @@
+../../devguide/examples/c/durability.cc

--- a/modules/howtos/examples/expiration.cc
+++ b/modules/howtos/examples/expiration.cc
@@ -1,0 +1,1 @@
+../../devguide/examples/c/expiration.cc

--- a/modules/howtos/examples/insert-upsert.cc
+++ b/modules/howtos/examples/insert-upsert.cc
@@ -1,0 +1,156 @@
+#include <string>
+#include <iostream>
+
+#include <libcouchbase/couchbase.h>
+
+static void die(const char *msg, lcb_STATUS err)
+{
+    std::cerr << "[ERROR] " << msg << ": " << lcb_strerror_short(err) << "\n";
+    exit(EXIT_FAILURE);
+}
+
+static void store_callback(lcb_INSTANCE *, int cbtype, const lcb_RESPSTORE *resp)
+{
+    lcb_STATUS rc = lcb_respstore_status(resp);
+    std::cerr << "=== " << lcb_strcbtype(cbtype) << " ===\n";
+    if (rc == LCB_SUCCESS) {
+        const char *key;
+        size_t nkey;
+        uint64_t cas;
+        lcb_respstore_key(resp, &key, &nkey);
+        std::cerr << "KEY: " << std::string(key, nkey) << "\n";
+        lcb_respstore_cas(resp, &cas);
+        std::cerr << "CAS: 0x" << std::hex << cas << "\n";
+    } else {
+        die(lcb_strcbtype(cbtype), rc);
+    }
+}
+
+// tag::retrieve[]
+static void get_callback(lcb_INSTANCE *instance, int cbtype, const lcb_RESPGET *resp)
+{
+    lcb_STATUS rc = lcb_respget_status(resp);
+    std::cerr << "=== " << lcb_strcbtype(cbtype) << " ===\n";
+    if (rc == LCB_SUCCESS) {
+        const char *key, *value;
+        size_t nkey, nvalue;
+        uint64_t cas;
+        uint32_t flags;
+        lcb_respget_key(resp, &key, &nkey);
+        std::cerr << "KEY: " << std::string(key, nkey) << "\n";
+        lcb_respget_cas(resp, &cas);
+        std::cerr << "CAS: 0x" << std::hex << cas << "\n";
+        lcb_respget_value(resp, &value, &nvalue);
+        std::cerr << "VALUE: " << std::string(value, nvalue) << "\n";
+        lcb_respget_flags(resp, &flags);
+        std::cerr << "FLAGS: 0x" << std::hex << flags << "\n";
+
+        {
+            // tag::async[]
+            // This snippet lives inside the callback, so it is not necessary to call lcb_wait here
+            lcb_CMDSTORE *cmd;
+            lcb_cmdstore_create(&cmd, LCB_STORE_INSERT);
+            lcb_cmdstore_key(cmd, key, nkey);
+            lcb_cmdstore_value(cmd, value, nvalue);
+
+            lcb_STATUS err = lcb_store(instance, nullptr, cmd);
+            lcb_cmdstore_destroy(cmd);
+            if (err != LCB_SUCCESS) {
+                die("Couldn't schedule storage operation", err);
+            }
+            // end::async[]
+        }
+    } else {
+        die(lcb_strcbtype(cbtype), rc);
+    }
+}
+// end::retrieve[]
+
+int main(int, char **)
+{
+    lcb_STATUS err;
+    lcb_INSTANCE *instance;
+    lcb_CREATEOPTS *create_options = nullptr;
+    lcb_CMDSTORE *scmd;
+    lcb_CMDGET *gcmd;
+
+    std::string connection_string = "couchbase://localhost";
+    std::string username = "Administrator";
+    std::string password = "password";
+
+    lcb_createopts_create(&create_options, LCB_TYPE_BUCKET);
+    lcb_createopts_connstr(create_options, connection_string.data(), connection_string.size());
+    lcb_createopts_credentials(create_options, username.data(), username.size(), password.data(), password.size());
+
+    err = lcb_create(&instance, create_options);
+    lcb_createopts_destroy(create_options);
+    if (err != LCB_SUCCESS) {
+        die("Couldn't create couchbase handle", err);
+    }
+
+    err = lcb_connect(instance);
+    if (err != LCB_SUCCESS) {
+        die("Couldn't schedule connection", err);
+    }
+
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+
+    err = lcb_get_bootstrap_status(instance);
+    if (err != LCB_SUCCESS) {
+        die("Couldn't bootstrap from cluster", err);
+    }
+
+    /* Assign the handlers to be called for the operation types */
+    lcb_install_callback(instance, LCB_CALLBACK_GET, reinterpret_cast<lcb_RESPCALLBACK>(get_callback));
+    lcb_install_callback(instance, LCB_CALLBACK_STORE, reinterpret_cast<lcb_RESPCALLBACK>(store_callback));
+
+    std::string key("key");
+    std::string value("value");
+
+    {
+        // tag::upsert[]
+        lcb_cmdstore_create(&scmd, LCB_STORE_UPSERT);
+        lcb_cmdstore_key(scmd, key.data(), key.size());
+        lcb_cmdstore_value(scmd, value.data(), value.size());
+
+        err = lcb_store(instance, nullptr, scmd);
+        lcb_cmdstore_destroy(scmd);
+        if (err != LCB_SUCCESS) {
+            die("Couldn't schedule storage operation", err);
+        }
+        lcb_wait(instance, LCB_WAIT_DEFAULT);
+        // end::upsert[]
+    }
+
+    {
+        // tag::insert[]
+        lcb_cmdstore_create(&scmd, LCB_STORE_INSERT);
+        lcb_cmdstore_key(scmd, key.data(), key.size());
+        lcb_cmdstore_value(scmd, value.data(), value.size());
+
+        err = lcb_store(instance, nullptr, scmd);
+        lcb_cmdstore_destroy(scmd);
+        if (err != LCB_SUCCESS) {
+            die("Couldn't schedule storage operation", err);
+        }
+        lcb_wait(instance, LCB_WAIT_DEFAULT);
+        // end::insert[]
+    }
+
+    /* Now fetch the item back */
+    lcb_cmdget_create(&gcmd);
+    lcb_cmdget_key(gcmd, key.data(), key.size());
+    err = lcb_get(instance, nullptr, gcmd);
+    if (err != LCB_SUCCESS) {
+        die("Couldn't schedule retrieval operation", err);
+    }
+    lcb_cmdget_destroy(gcmd);
+
+    /* Likewise, the get_callback is invoked from here */
+    std::cerr << "Will wait to retrieve item..\n";
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+
+    /* Now that we're all done, close down the connection handle */
+    lcb_destroy(instance);
+    return 0;
+}

--- a/modules/howtos/examples/query-criteria.cc
+++ b/modules/howtos/examples/query-criteria.cc
@@ -1,0 +1,1 @@
+../../devguide/examples/c/query-criteria.cc

--- a/modules/howtos/examples/query-placeholders.cc
+++ b/modules/howtos/examples/query-placeholders.cc
@@ -1,0 +1,1 @@
+../../devguide/examples/c/query-placeholders.cc

--- a/modules/howtos/examples/subdoc-retrieving.cc
+++ b/modules/howtos/examples/subdoc-retrieving.cc
@@ -1,0 +1,1 @@
+../../devguide/examples/c/subdoc-retrieving.cc

--- a/modules/howtos/examples/subdoc-updating.cc
+++ b/modules/howtos/examples/subdoc-updating.cc
@@ -1,0 +1,1 @@
+../../devguide/examples/c/subdoc-updating.cc

--- a/modules/howtos/examples/views.cc
+++ b/modules/howtos/examples/views.cc
@@ -1,0 +1,115 @@
+/* -*- Mode: C; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *     Copyright 2013-2020 Couchbase, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <libcouchbase/couchbase.h>
+#include <string>
+#include <cstring>
+#include <cstdlib>
+#include <cstdio>
+#include <iostream>
+
+static void check(lcb_STATUS err)
+{
+    if (err != LCB_SUCCESS) {
+        std::cerr << "ERROR: " << lcb_strerror_short(err) << "\n";
+        exit(EXIT_FAILURE);
+    }
+}
+
+static int cbCounter = 0;
+
+extern "C" {
+static void viewCallback(lcb_INSTANCE *, int, const lcb_RESPVIEW *rv)
+{
+    lcb_STATUS rc = lcb_respview_status(rv);
+
+    if (lcb_respview_is_final(rv)) {
+        const char *row;
+        size_t nrow;
+        lcb_respview_row(rv, &row, &nrow);
+        printf("*** META FROM VIEWS ***\n");
+        fprintf(stderr, "%.*s\n", (int)nrow, row);
+        return;
+    }
+
+    const char *key, *docid;
+    size_t nkey, ndocid;
+    lcb_respview_key(rv, &key, &nkey);
+    lcb_respview_doc_id(rv, &docid, &ndocid);
+    printf("Got row callback from LCB: RC=0x%X, DOCID=%.*s. KEY=%.*s\n", rc, (int)ndocid, docid, (int)nkey, key);
+
+    const lcb_RESPGET *doc = nullptr;
+    lcb_respview_document(rv, &doc);
+    if (doc) {
+        rc = lcb_respget_status(doc);
+        uint64_t cas;
+        lcb_respget_cas(doc, &cas);
+        printf("   Document for response. RC=0x%X. CAS=0x%llx\n", rc, (long long)cas);
+    }
+
+    cbCounter++;
+}
+}
+
+int main(int argc, const char **argv)
+{
+    lcb_INSTANCE *instance;
+    lcb_CREATEOPTS *create_options = nullptr;
+    const char *connstr = "couchbase://localhost/beer-sample";
+
+    if (argc > 1) {
+        if (strcmp(argv[1], "--help") == 0) {
+            fprintf(stderr, "Usage: %s CONNSTR [USERNAME PASSWORD]\n", argv[0]);
+            exit(EXIT_SUCCESS);
+        } else {
+            connstr = argv[1];
+        }
+    }
+
+    lcb_createopts_create(&create_options, LCB_TYPE_BUCKET);
+    lcb_createopts_connstr(create_options, connstr, strlen(connstr));
+    if (argc > 3) {
+        lcb_createopts_credentials(create_options, argv[2], strlen(argv[2]), argv[3], strlen(argv[3]));
+    }
+    check(lcb_create(&instance, create_options));
+    lcb_createopts_destroy(create_options);
+    check(lcb_connect(instance));
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+    check(lcb_get_bootstrap_status(instance));
+
+    // Now, set up the views..
+    // tag::views[]
+    lcb_CMDVIEW *vq;
+    std::string dName = "beer";
+    std::string vName = "by_location";
+    std::string options = "reduce=false";
+
+    lcb_cmdview_create(&vq);
+    lcb_cmdview_callback(vq, viewCallback);
+    lcb_cmdview_design_document(vq, dName.c_str(), dName.size());
+    lcb_cmdview_view_name(vq, vName.c_str(), vName.size());
+    lcb_cmdview_option_string(vq, options.c_str(), options.size());
+    lcb_cmdview_include_docs(vq, true);
+    // end::views[]
+    check(lcb_view(instance, nullptr, vq));
+    lcb_cmdview_destroy(vq);
+
+    lcb_wait(instance, LCB_WAIT_DEFAULT);
+    lcb_destroy(instance);
+    printf("Total Invocations=%d\n", cbCounter);
+    return 0;
+}

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -13,9 +13,9 @@ The analytics service is available in Couchbase Data Platform 6.0 and later (dev
 == Getting Started
 
 After familiarizing yourself with our xref:6.5@server:analytics:primer-beer.adoc[introductory primer],
-in particular creating a dataset and linking it to a bucket to shadow the operational data, 
+in particular creating a dataset and linking it to a bucket to shadow the operational data,
 try Couchbase Analytics using the Go SDK.
-Intentionally, the API for analytics is very similar to that of the query service. 
+Intentionally, the API for analytics is very similar to that of the query service.
 In these examples we will be using an `airports` dataset created on the `travel-sample` bucket.
 
 In Go SDK 1.x, Analytics was only available on the `Bucket` object;
@@ -24,10 +24,40 @@ in Go SDK 2.0, Analytics queries are submitted using the Cluster reference, not 
 NOTE: When using a Couchbase version < 6.5 you must create a valid Bucket connection using `cluster.Bucket(name)` before you can use Analytics.
 
 
+Here is an example of doing an analytics query :
 
-== Example 
-
+[source,c]
+----
+include::example$analytics.cc[tag=analytics,indent=0]
+----
 For a full example, see the https://docs.couchbase.com/sdk-api/couchbase-c-client/example_2analytics_2analytics_8c-example.html[API documentation].
+
+== Analytics Result
+
+When performing an analytics query, `lcb_RESPANALYTICS` is delivered in the `lcb_ANALYTICS_CALLBACK` function for each result row received.
+
+[source,c]
+----
+include::example$analytics.cc[tag=result, indent=0]
+----
+
+== Analytics Options
+
+The analytics service provides an array of options to customize your query. The following table lists them :
+
+.Available Analytics options
+[options="header"]
+|====
+| Name    | Description
+| `lcb_cmdanalytics_reset(command)` | Reset the structure so that it may be reused for a subsequent analytics query.
+| `lcb_cmdanalytics_encoded_payload(command,query,query length)` | Get the JSON-encoded analytics query payload.
+| `lcb_cmdanalytics_payload(command, query, query length)` | Sets the JSON-encodes analytics query payload to be executed.
+| `lcb_cmdanalytics_statement(command, statement, statement length )` | Sets the actual statement to be executed.
+| `lcb_cmdanalytics_scope_name(command, scope name, scope length)` | Associate scope name with the analytics query.
+| `lcb_cmdanalytics_named_param(command, argument name, name length, argument value, value length)` | Sets a named argument for the analytics query.
+| `lcb_cmdanalytics_positional_param(command, argument value, argument length)` | Adds a positional argument for the analytics query.
+| `lcb_cmdanalytics_readonly(command, readonly)` | Marks analytics query as read-only ( set readonly value to non zero ).
+|====
 
 ////
 [source,golang,indent=0]
@@ -37,7 +67,7 @@ include::example$analytics.go[tag=query]
 
 == Queries
 
-A query can either be `simple` or be `parameterized`. If parameters are used, they can either be `positional` or `named`. 
+A query can either be `simple` or be `parameterized`. If parameters are used, they can either be `positional` or `named`.
 Here is one example of each:
 
 [source,golang,indent=0]
@@ -69,9 +99,9 @@ Additional parameters may be sent as part of the query.
 There are currently three parameters:
 
 * *Client Context ID*, sets a context ID that is returned back as part of the result.
-Uses `ClientContextID string` default is a random UUID 
+Uses `ClientContextID string` default is a random UUID
 * *Timeout*, customizes the timeout sent to the server.
-Does not usually have to be set, as the client sets it based on the timeout on the operation. 
+Does not usually have to be set, as the client sets it based on the timeout on the operation.
 Uses `Timeout time.Duration`, and defaults to the Analytics timeout set on the client (75s).
 This can be adjusted at the xref:ref:client-settings.adoc#timeout-options[cluster global config level].
 * *Priority*, set if the request should have priority over others.
@@ -88,9 +118,9 @@ include::example$analytics.go[tag=options]
 
 == Handling the Response
 
-These query result may contain various sorts of data and metadata, 
-depending upon the nature of the query, 
-as you will have seen when working through our xref:6.5@server:analytics:primer-beer.adoc[introductory primer]. 
+These query result may contain various sorts of data and metadata,
+depending upon the nature of the query,
+as you will have seen when working through our xref:6.5@server:analytics:primer-beer.adoc[introductory primer].
 
 Results are iterated using the `Next` function.
 Within the `for` loop the result is read using the `Row` by supplying a pointer to the variable in which to store the value.
@@ -104,7 +134,7 @@ include::devguide:example$go/analytics-simple-query.go[tag=results]
 // Move these to Error reference doc?
 Common errors are listed in our xref:ref:error-codes.adoc#analytics-errors[Errors Reference doc], with errors caused by resource unavailability (such as timeouts and _Operation cannot be performed during rebalance_ messages) leading to an xref:howtos:error-handling.adoc#retry[automatic retry] by the SDK.
 
-If you only expect a single result or only want to use the first result in a results set then you can use `One` 
+If you only expect a single result or only want to use the first result in a results set then you can use `One`
 (note: this function will iterate any remaining rows in the resultset so can only be called once and should only be used on small results sets):
 
 [source,golang,indent=0]
@@ -138,8 +168,6 @@ For a listing of available `Metrics` in `MetaData`, see the xref:concept-docs:an
 ////
 
 
-== Additional Resources 
+== Additional Resources
 
 To learn more about using N1QL for Analytics -- the first commercial implementation of SQL\++ -- see our https://sqlplusplus-tutorial.couchbase.com/tutorial/#1[Tutorial Introduction to SQL++ for SQL users].
-
-

--- a/modules/howtos/pages/concurrent-async-apis.adoc
+++ b/modules/howtos/pages/concurrent-async-apis.adoc
@@ -10,9 +10,7 @@ Async & batching
 Libcouchbase is an asynchronous client that may also be used in blocking mode.
 The library contains I/O plugins for common libraries such as _libevent_, _libev_, and _libuv_, and a libevent-based example can be found https://docs.couchbase.com/sdk-api/couchbase-c-client/example_2libeventdirect_2main_8c-example.html[here].
 
-
 Batching examples are given for https://github.com/couchbase/docs-sdk-c/blob/release/3.1/modules/devguide/examples/c/bulk-store.cc[bulk store] and for https://github.com/couchbase/docs-sdk-c/blob/release/3.1/modules/devguide/examples/c/bulk-get.cc[bulk get].
-
 
 == Usage Differences in Non-Blocking Mode
 
@@ -43,3 +41,12 @@ You need to use the callback variant that notifies your application when the lib
 Likewise, you are responsible for freeing the `iops` structure via [.api]`lcb_destroy_io_opts()` when it is no longer required.
 * Currently the library does blocking DNS look-ups via the standard [.api]`getaddrinfo()` call.
 Typically this should not take a long time but may potentially block your application if an invalid host name is detected or the DNS server in use is slow to respond.
+
+== Batching
+
+The most simplistic bulk fetch looks like this:
+
+[source,c]
+----
+include::example$bulk-get.cc[tag=batching,indent=0]
+----

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -22,90 +22,17 @@ Or read on, for a hands-on introduction to working with documents from the .NET 
 The core interface to Couchbase Server is simple KV operations on full documents.
 Make sure you're familiar with the basics of authorization and connecting to a Cluster from the xref:hello-world:start-using-sdk.adoc[Start Using the SDK section].
 
-See the https://github.com/couchbase/docs-sdk-c/blob/release/3.1/modules/devguide/examples/c/retrieving.cc[code sample^] for use in context.
-////
-We're going to expand on the short _Upsert_ example we used there, adding options as we move through the various CRUD operations.
-Here is the _Insert_ operation at its simplest:
+See the https://github.com/couchbase/docs-sdk-c/blob/release/3.0/modules/devguide/examples/c/retrieving.cc[code sample^] for use in context.
 
-[source,csharp]
-----
-Insert
-var document = new {foo = "bar", bar = "foo"};
-var result = await collection.Insert("document-key", document);
-----
-
-Options may be added to operations:
-
-[source,csharp]
-----
-Insert (with options)
-var document = new {foo = "bar", bar = "foo"};
-var result = await collection.Insert("document-key", document,
-    new InsertOptions
-    {
-        Cas = 12345,
-        Timeout = TimeSpan.FromSeconds(5)
-    }
-);
-----
-////
-Setting a Compare and Swap (CAS) value is a form of optimistic locking - dealt with in depth in the xref:concurrent-document-mutations.adoc[CAS page].
-Here we just note that the CAS is a value representing the current state of an item; each time the item is modified, its CAS changes.
-The CAS value is returned as part of a document’s metadata whenever a document is accessed.
-Without explicitly setting it, a newly-created document would have a CAS value of _0_.
-////
-_Timeout_ is an optional parameter which in the .NET SDK has a type value of `TimeSpan`.
-Timeout sets the timeout value for the underlying network connection.
-We will add to these options for the _Replace_ example:
-
-[source,csharp]
-----
-var document = new {foo = "bar", bar = "foo"};
-var result = await collection.Replace("document-key", document,
-    new ReplaceOptions
-    {
-        Cas = 12345,
-        Expiration = TimeSpan.FromMinutes(1),
-        Timeout = TimeSpan.FromSeconds(5)
-    }
-);
-----
-
-Expiration sets an explicit time to live (TTL) for a document.
-We'll discuss modifying `Expiration` in more details xref:#expiration-ttl[below].
-For a discussion of item (Document) _vs_ Bucket expiration, see the
-xref:6.5@server:learn:buckets-memory-and-storage/expiration.adoc#expiration-bucket-versus-item[Expiration Overview page].
-
-[source,csharp]
-----
-var document = new {foo = "bar", bar = "foo"};
-var result = await collection.Upsert("document-key", document,
-    new UpsertOptions
-    {
-        Cas = 12345,
-        Expiration = TimeSpan.FromMinutes(1),
-        PersistTo = PersistTo.One,
-        ReplicateTo = ReplicateTo.One,
-        Timeout = TimeSpan.FromSeconds(5)
-    }
-);
-----
-
-Here, we have add _Durability_ options, namely `PersistTo` and `ReplicateTo`.
-////
-
-See the https://github.com/couchbase/docs-sdk-c/blob/release/3.1/modules/devguide/examples/c/cas.cc[code sample^] for use in context.
-////
-In Couchbase Server releases before 6.5, Durability was set with these two options -- see the xref:https://docs.couchbase.com/dotnet-sdk/2.7/durability.html[6.0 Durability documentation] -- covering  how many replicas the operation must be propagated to and how many persisted copies of the modified record must exist.
-Couchbase Data Platform 6.5 refines these two options, with xref:6.5@server:learn:data/durability.adoc[Synchronous Replication] -- although they remain essentially the same in use -- see xref:#durability[Durability, below].
-////
+== Upsert
 
 [TIP]
 .Sub-Document Operations
 ====
 All of these operations involve fetching the complete document from the Cluster.
-Where the number of operations or other circumstances make bandwidth a significant issue, the SDK can work on just a specific _path_ of the document with xref:subdocument-operations.adoc[Sub-Docunent Operations].
+Where the number of operations or other circumstances make bandwidth a significant issue, the SDK can work on just a specific _path_ of the document with xref:subdocument-operations.adoc[Sub-Document Operations].
 ====
+
 ////
 == Retrieving full documents
 
@@ -151,6 +78,101 @@ var result = await collection.Remove("document-key",
 ----
 ////
 
+Here is a simple upsert operation, which will insert the document if it does not exist, or replace it if it does.
+
+We use `lcb_cmdstore_create` for storing an item in Couchbase as it is only one operation with different set of
+attributes/constraints for storage modes.
+[source,c]
+----
+include::example$insert-upsert.cc[tag=upsert]
+----
+
+== Insert
+
+Insert works very similarly to upsert , but will fail if the document already exists.
+[source,c]
+----
+include::example$insert-upsert.cc[tag=insert]
+----
+
+== Retrieving documents
+
+We've tried upserting and inserting documents into the Couchbase Server, let's get them back:
+[source,c]
+----
+include::example$insert-upsert.cc[tag=retrieve]
+----
+== Replace
+
+A very common sequence  of operations is to `get` a document, modify its contents, and `replace` it.
+// Insert code sample here
+So what is CAS?
+
+CAS, or  Compare and  Swap, is a form of optimistic locking. Every  document is Couchbase has a CAS value,
+and it's changed on every mutation. When you get a document you also get the document's CAS, and then when it
+is time to write the document, you send the same CAS back. If another thread or program has  modified that document
+in the  meantime, the  Couchbase Server can detect you've provided a now-outdated CAS, and return an error. This provides
+cheap and safe concurrency. See this xref:concurrent-document-mutations.adoc[this detailed description of CAS] for further details.
+
+In general, you'll want to provide a CAS value whenever you `replace` a document, to prevent overwriting another agent's mutations.
+
+Setting a Compare and Swap (CAS) value is a form of optimistic locking - dealt with in depth in the xref:concurrent-document-mutations.adoc[CAS page].
+Here we just note that the CAS is a value representing the current state of an item; each time the item is modified, its CAS changes.
+The CAS value is returned as part of a document’s metadata whenever a document is accessed.
+Without explicitly setting it, a newly-created document would have a CAS value of _0_.
+////
+_Timeout_ is an optional parameter which in the .NET SDK has a type value of `TimeSpan`.
+Timeout sets the timeout value for the underlying network connection.
+We will add to these options for the _Replace_ example:
+
+[source,csharp]
+----
+var document = new {foo = "bar", bar = "foo"};
+var result = await collection.Replace("document-key", document,
+    new ReplaceOptions
+    {
+        Cas = 12345,
+        Expiration = TimeSpan.FromMinutes(1),
+        Timeout = TimeSpan.FromSeconds(5)
+    }
+);
+----
+
+Expiration sets an explicit time to live (TTL) for a document.
+We'll discuss modifying `Expiration` in more details xref:#expiration-ttl[below].
+For a discussion of item (Document) _vs_ Bucket expiration, see the
+xref:6.5@server:learn:buckets-memory-and-storage/expiration.adoc#expiration-bucket-versus-item[Expiration Overview page].
+
+[source,csharp]
+----
+var document = new {foo = "bar", bar = "foo"};
+var result = await collection.Upsert("document-key", document,
+    new UpsertOptions
+    {
+        Cas = 12345,
+        Expiration = TimeSpan.FromMinutes(1),
+        PersistTo = PersistTo.One,
+        ReplicateTo = ReplicateTo.One,
+        Timeout = TimeSpan.FromSeconds(5)
+    }
+);
+----
+
+Here, we have add _Durability_ options, namely `PersistTo` and `ReplicateTo`.
+////
+[source,c]
+----
+include::example$cas.cc[tag=cas]
+----
+
+See the https://github.com/couchbase/docs-sdk-c/blob/release/3.1/modules/devguide/examples/c/cas.cc[code sample^] for use in context.
+////
+In Couchbase Server releases before 6.5, Durability was set with these two options -- see the xref:https://docs.couchbase.com/dotnet-sdk/2.7/durability.html[6.0 Durability documentation] -- covering  how many replicas the operation must be propagated to and how many persisted copies of the modified record must exist.
+Couchbase Data Platform 6.5 refines these two options, with xref:6.5@server:learn:data/durability.adoc[Synchronous Replication] -- although they remain essentially the same in use -- see xref:#durability[Durability, below].
+////
+
+
+
 == Durability
 Writes in Couchbase are written to a single node, and from there the Couchbase Server will take care of sending that mutation to any configured replicas.
 
@@ -162,7 +184,6 @@ It can be used like this:
 ----
 // durability kv snippet
 ----
-////
 See the https://github.com/couchbase/docs-sdk-c/blob/release/3.1/modules/devguide/examples/c/durability.cc[code sample^] for use in context.
 
 If no argument is provided the application will report success back as soon as the primary node has acknowledged the mutation in its memory.
@@ -184,22 +205,25 @@ These trade offs, as well as which settings may be tuned, are discussed in the x
 
 If a version of Couchbase Server lower than 6.5 is being used then the application can fall-back to xref:concept-docs:durability-replication-failure-considerations.adoc#older-server-versions['client verified' durability.]
 Here the SDK will do a simple poll of the replicas and only return once the requested durability level is achieved.
-////
 This can be achieved like this:
 
 [source,c]
 ----
-// Durability observed snippet
+include::example$durability.cc[tag=durability]
 ----
-////
 To stress, durability is a useful feature but should not be the default for most applications, as there is a performance consideration,
 and the default level of safety provided by Couchbase will be reasonable for the majority of situations.
 
 == Expiration / TTL
 
-By default, Couchbase documents do not expire, but transient or temporary data may be needed for user sessions, caches, or other temporary documents.
-Using `Touch()`, you can set expiration values on documents to handle transient data.
-////
+Couchbase Server includes an option top have particular documents automatically expire after a set time. This can be useful is some use cases,
+such as user sessions, caches, or other temporary documents.
+
+You can set an expiry value to `lmd_cmdstore_expiry` when creating a document:
+[source,c]
+----
+include::example$expiration.cc[tag=expiration]
+----
 
 [source,csharp]
 ----
@@ -221,12 +245,18 @@ var result = await collection.Touch("document-key", TimeSpan.FromSeconds(30),
 
 See the https://github.com/couchbase/docs-sdk-c/blob/release/3.1/modules/devguide/examples/c/expiration.cc[code sample^] for use in context.
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=exp-note]
+
 
 
 == Atomic Counters
 
-The value of a document can be increased or decreased atomically using `Binary.Increment()` and `.Binary.Decrement()`.
+The numeric content of a document can be manipulated using https://docs.couchbase.com/sdk-api/couchbase-c-client/group__lcb-counter.html[lcb_RESPCOUNTER^]. Counter opeations treat the document
+as a numeric value (the document must contain a parseable integer as its content). This value may then be incremented
+or decremented.
+[source,c]
+----
+include::example$atomic-counters.cc[tag=atomic-counter]
+----
 ////
 .Increment
 [source,csharp]
@@ -280,4 +310,3 @@ For working with metadata on a document, reference our xref:sdk-xattr-example.ad
 // As well as various xref:concept-docs:data-model.adoc[Formats] of JSON, Couchbase can work directly with xref:concept-docs:nonjson.adoc[arbitary bytes, or binary format].
 
 Our xref:n1ql-queries-with-sdk.adoc[Query Engine] enables retrieval of information using the SQL-like syntax of N1QL.
-

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -14,18 +14,53 @@ In this case, the one thing that you need to know is that in order to make a Buc
 You can define a _primary_ index on a bucket.
 When a primary index is defined you can issue non-covered queries on the bucket as well.
 
-Use
-xref:6.5@server::tools/cbq-shell.html[cbq], our interactive Query shell.
-Open it, and enter the following:
-
-[source,n1ql]
+[source,c]
 ----
-CREATE PRIMARY INDEX ON `travel-sample`
+include::example$query-criteria.cc[tag=query]
 ----
 
-or replace _travel-sample_ with a different Bucket name to build an index on a different dataset.
+== Queries & Placeholders
 
-NOTE: The default installation places cbq in `/opt/couchbase/bin/` on Linux, `/Applications/Couchbase Server.app/Contents/Resources/couchbase-core/bin/cbq` on OS X, and `C:\Program Files\Couchbase\Server\bin\cbq.exe` on Microsoft Windows.
+Placeholders allow you to specify variable constraints for an otherwise constant query.
+There are two variants of placeholders: postional and named parameters.
+Positional parameters use an ordinal placeholder for substitution and named parameters use variables.
+Note that both parameters and options are optional.
+
+[source,c]
+----
+include::example$query-placeholders.cc[tag=placeholder]
+----
+
+
+== The Query Result
+
+The result for each query is JSON and as a result queries will function the same regardless whether they are executed using the _cbq_ shell, an SDK, or using the  REST API directly.
+Nevertheless, the result format recieved using an SDK may be different than that received using the `cbq` or the REST API.
+
+== Query Options
+
+.Available Query options
+[options="header"]
+|====
+| Name    | Description
+| `lcb_cmdquery_reset(command)` | Reset the structure so that it may be reused for a subsequent query.
+| `lcb_cmdquery_encoded_payload(command,payload,payload length)` | Get the JSON-encoded query payload.
+| `lcb_cmdquery_payload(command, query, query length)` | Sets the JSON-encodes query payload to be executed.
+| `lcb_cmdquery_statement(command, statement, statement length )` | Sets the actual statement to be executed.
+| `lcb_cmdquery_scope_name(command, scope name, scope length)` | Associate scope name with the query.
+| `lcb_cmdquery_named_param(command, argument name, name length, argument value, value length)` | Sets a named argument for the query.
+| `lcb_cmdquery_positional_param(command, argument value, argument length)` | Adds a positional argument for the query.
+| `lcb_cmdquery_readonly(command, readonly)` | Marks query as read-only ( set readonly value to non zero ).
+| `lcb_cmdquery_scan_cap(command, value)` | Sets maximum buffered channel size between the indexer client and the query service for index scans.
+| `lcb_cmdquery_flex_index(command, value)` | Tells the query engine to use a flex index (utilizing the search service).
+| `lcb_cmdquery_pipeline_cap(command, item number)` | Sets maximum number of items each execution operator can buffer between various operators.
+| `lcb_cmdquery_pipeline_batch(command, item number)` | Sets the number of items execution operators can batch for fetch from the KV.
+| `lcb_cmdquery_consistency(command, mode)` | Sets the consistency mode for the request.
+| `lcb_cmdquery_consistency_token_for_keyspace(command, keyspace, keyspace length, token)` | Indicate that the query should synchronize its internal snapshot to reflect the changes indicated by the given mutation token.
+| `lcb_cmdquery_option(command, option name, name length, option value, value length)` | Set a query option.
+|====
+
+
 
 
 
@@ -245,4 +280,3 @@ The http://query.pub.couchbase.com/tutorial/#1[N1QL interactive tutorial] is a g
 // Indexes / GSI links?
 
 // SQL++ / Analytics.
-

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -13,14 +13,15 @@ Sub-document operations are also atomic, allowing safe modifications to document
 
 Starting with Couchbase Server 4.5 you can atomically and efficiently update and retrieve _parts_ of a document.
 These parts are called _sub-documents_.
+
+
 While full-document retrievals retrieve the entire document and full document updates require sending the entire document, sub-document retrievals only retrieve relevant parts of a document and sub-document updates only require sending the updated portions of a document.
 You should use sub-document operations when you are modifying only portions of a document, and full-document operations when the contents of a document is to change significantly.
 
 IMPORTANT: The sub-document operations described on this page are for _Key-Value_ requests only: they are not related to sub-document N1QL queries.
 (Sub-document N1QL queries are explained in the section xref:concept-docs:n1ql-query.adoc[Querying with N1QL].)
 
-In order to use sub-document operations you need to specify a _path_ indicating the location of the sub-document.
-The _path_ follows N1QL syntax (see <<#path-syntax,below>>, and xref:6.5@server:n1ql:n1ql-intro/queriesandresults.adoc[N1QL Queries and Results]).
+
 Considering the document:
 
 .customer123.json
@@ -60,25 +61,17 @@ The paths `name`, `addresses.billing.country` and `purchases.complete[0]` are al
 The _lookup-in_ operations query the document for certain path(s); these path(s) are then returned.
 You have a choice of actually retrieving the document path using the _subdoc-get_ sub-document operation, or simply querying the existence of the path using the _subdoc-exists_ sub-document operation.
 The latter saves even more bandwidth by not retrieving the contents of the path if it is not needed.
-////
-.Retrieve sub-document value
-[source,csharp]
+
+.Check existence of Subdocument path
+[source,c]
 ----
-var result = collection.LookupIn("customer123", ops =>
-    ops.Get("addresses.delivery.country")
-);
-var country = result.ContentAs<string>(0); //"United Kingdom"
+include::example$subdoc-retrieving.cc[tag=sub-doc-exists]
 ----
 
-.Check existence of sub-document path
-[source,csharp]
+.Retrieve Subdocument value
+[source,c]
 ----
-var result = collecton.LookupIn("customer123", ops =>
-    ops.Exists("purchases.pending[-1]")
-);
-Console.WriteLine("Path exists? {0}", result.ContentAs<bool>(0));
-
-# Path exists? false
+include::example$subdoc-retrieving.cc[tag=sub-doc-retrieve]
 ----
 
 Multiple operations can be combined as well:
@@ -98,12 +91,38 @@ Console.WriteLine("Path exists? {0}", result.ContentAs<bool>(1));
 
 See the https://github.com/couchbase/docs-sdk-c/blob/release/3.1/modules/devguide/examples/c/subdoc-retrieving.cc[code sample^] for use in context.
 
+
+== Choosing an API
+
+_libcouchbase_ is an asynchronous library which means that operations results are passed to callbacks you define rather than being returned to functions.
+Callbacks are passed a `cookie` parameter which is a user defined pointer (i.e your own pointer, which can be `NULL`) to associate a specific command with a specific callback invocation.
+
+[source,c]
+----
+include::example$insert-upsert.cc[tag=upsert]
+----
+
+For simple synchronous use, you will need to call `lcb_wait()` after each set of scheduled operations.
+During `lcb_wait` the library will block for I/O, and invoke your callbacks as the results of the operations arrive.
+
+[source,c]
+----
+include::example$insert-upsert.cc[tag=async]
+----
+
+See the https://docs.couchbase.com/sdk-api/couchbase-c-client/example_2minimal_2minimal_8c-example.html#a5[code sample^] for use in context.
+
+
 == Mutating
 
 Mutation operations modify one or more paths in the document.
 The simplest of these operations is _subdoc-upsert_, which, similar to the fulldoc-level _upsert_, will either modify the value of an existing path or create it if it does not exist.
 
-See the https://github.com/couchbase/docs-sdk-c/blob/release/3.1/modules/devguide/examples/c/subdoc-retrieving.cc[code sample^] for use in context.
+[source,c]
+----
+include::example$subdoc-updating.cc[tag=sub-doc-mutate]
+----
+See the https://github.com/couchbase/docs-sdk-c/blob/release/3.0/modules/devguide/examples/c/subdoc-retrieving.cc[code sample^] for use in context.
 
 ////
 .Upserting a new sub-document
@@ -140,6 +159,7 @@ bucket.MutateIn("customer123", ops => {
 
 NOTE: `mutateIn` is an _atomic_ operation.
 If any single `ops` fails, then the entire document is left unchanged.
+
 ////
 == Array append and prepend
 
@@ -247,26 +267,27 @@ Note that currently the _addunique_ will fail with a _Path Mismatch_ error if th
 The _addunique_ operation will also fail with _Cannot Insert_ if the value to be added is one of those types as well.
 
 Note that the actual position of the new element is undefined, and that the array is not ordered.
-
+////
 == Array insertion
 
 New elements can also be _inserted_ into an array.
 While _append_ will place a new item at the _end_ of an array and _prepend_ will place it at the beginning, _insert_ allows an element to be inserted at a specific _position_.
 The position is indicated by the last path component, which should be an array index.
-For example, to insert `"cruel"` as the second element in the array `["Hello", "world"]`, the code would look like:
+For example, to insert `"42"` as the last element in the array `[1,2,3,4]`, the code would look like:
 
-[source,csharp]
+[source,c]
 ----
-bucket.MutateIn("array", ops =>
-    ops.ArrayInsert("[1]", "cruel")
-);
+std::string value_to_add{ "42" };
+check(lcb_subdocspecs_array_add_last(specs, 0, 0, paths[0].c_str(), paths[0].size(), value_to_add.c_str(), value_to_add.size()),"create ARRAY_ADD_LAST operation");
+
+
 ----
 
 // for your examples, above, CD: “I feel like somewhere in this we should also just a an example path like "my.path[1]" too, just to show how to use the index with a nested path. I don't think it's necessarily clear.”
 
 Note that the array must already exist and that the index must be valid (i.e.
 it must not point to an element which is out of bounds).
-
+////
 == Counters and numeric fields
 
 Counter operations allow the manipulation of a _numeric_ value inside a document.

--- a/modules/howtos/pages/view-queries-with-sdk.adoc
+++ b/modules/howtos/pages/view-queries-with-sdk.adoc
@@ -12,6 +12,19 @@ include::6.5@sdk:shared:partial$views.adoc[tag=views-intro]
 
 You can find further information https://docs.couchbase.com/sdk-api/couchbase-c-client/group__lcb-view-api.html[in the API docs].
 
+== Querying Views
+
+View operations are accessible via `lcb_CMDVIEW`.
+Once you have a reference to the bucket you need to at least supply the name of the design document and the name of the view:
+
+[source,c]
+----
+include::example$views.cc[tag=views,indent=0]
+----
+//== Working with View Rows
+
+
+
 ////
 include::6.5@sdk:shared:partial$views.adoc[tag=example-beer]
 


### PR DESCRIPTION
I have consolidated changes from those two PRs: #89  and #92

As for examples, I found that most of the were copies examples from `devguide/` directory, so I created symlinks and added tags into original copies. If it is possible for anthora, maybe we should even fix references in `howtos/` module to point to `devguide/` examples directly (as they now have decessary tags)

Also I have ensured that all examples compilable, and added cmake definition, so that one can create new project in CLion and import that `CMakeLists.txt`