### PR TITLE
Fix typo: docs-sdk-c pointed to java

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -3,4 +3,4 @@
 :page-topic-type: project-doc
 :page-aliases: ROOT:sdk-release-notes,ROOT:relnotes-c-sdk,ROOT:release-notes,ROOT:download-install,ROOT:download-list
 
-include::3.2@java-sdk:project-docs:page$sdk-release-notes.adoc[tag=all]
+include::3.2@c-sdk:project-docs:page$sdk-release-notes.adoc[tag=all]


### PR DESCRIPTION
I can't confirm the final document generation result, but according to the naming convention, this correction should be OK, you'd better to double confirm.