### PR TITLE
CCBC-1441 lcb_cmd{query,analytics}_positional_params

### DIFF
--- a/modules/devguide/examples/c/query-atplus.cc
+++ b/modules/devguide/examples/c/query-atplus.cc
@@ -1,3 +1,12 @@
+/*
+ * REQUIREMENTS
+ *   Running couchbase server on localhost with:
+ *   user: some-user/some-password
+ *         with some RBAC (just used Full Admin for now)
+ *   bucket "default"
+ *   CREATE PRIMARY INDEX ON `default`:`default`
+ */
+
 #include <string>
 #include <vector>
 #include <iostream>

--- a/modules/devguide/examples/c/query-atplus.cc
+++ b/modules/devguide/examples/c/query-atplus.cc
@@ -138,14 +138,18 @@ main(int, char **)
     {
         std::string statement =
                 "SELECT name, email, random FROM `" + bucket_name + "` WHERE $1 IN name LIMIT 100";
-        std::string param = R"("Brass")";
 
+        std::string parameters_json = "[\"Brass\"]";
+        
         lcb_CMDQUERY *cmd = nullptr;
         check(lcb_cmdquery_create(&cmd), "create QUERY command");
         check(lcb_cmdquery_statement(cmd, statement.c_str(), statement.size()),
                 "assign statement for QUERY command");
-        check(lcb_cmdquery_positional_param(cmd, param.c_str(), param.size()),
-                "add positional parameter for QUERY command");
+        check(lcb_cmdquery_positional_params
+                        (cmd,
+                        parameters_json.c_str(),
+                        parameters_json.length()),
+                "set QUERY positional parameters");
         check(lcb_cmdquery_consistency_token_for_keyspace(cmd, bucket_name.c_str(),
                         bucket_name.size(),
                         &mutation_token),

--- a/modules/devguide/examples/c/query-consistency.cc
+++ b/modules/devguide/examples/c/query-consistency.cc
@@ -1,3 +1,12 @@
+/*
+ * REQUIREMENTS
+ *   Running couchbase server on localhost with:
+ *   user: some-user/some-password
+ *         with some RBAC (just used Full Admin for now)
+ *   bucket "default"
+ *   CREATE PRIMARY INDEX ON `default`:`default`
+ */
+ 
 #include <string>
 #include <vector>
 #include <iostream>
@@ -113,13 +122,13 @@ main(int, char **)
     {
         std::string statement =
                 "SELECT name, email, random FROM `" + bucket_name + "` WHERE $1 IN name LIMIT 100";
-        std::string param = R"("Brass")";
+        std::string parameters_json = "[\"Brass\"]";
 
         lcb_CMDQUERY *cmd = nullptr;
         check(lcb_cmdquery_create(&cmd), "create QUERY command");
         check(lcb_cmdquery_statement(cmd, statement.c_str(), statement.size()),
                 "assign statement for QUERY command");
-        check(lcb_cmdquery_positional_param(cmd, param.c_str(), param.size()),
+        check(lcb_cmdquery_positional_params(cmd, parameters_json.c_str(), parameters_json.length()),
                 "add positional parameter for QUERY command");
         check(lcb_cmdquery_consistency(cmd, LCB_QUERY_CONSISTENCY_REQUEST),
                 "assign consistency level for QUERY command");

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -59,7 +59,8 @@ The analytics service provides an array of options to customize your query. The 
 | `lcb_cmdanalytics_statement(command, statement, statement length )` | Sets the actual statement to be executed.
 | `lcb_cmdanalytics_scope_name(command, scope name, scope length)` | Associate scope name with the analytics query.
 | `lcb_cmdanalytics_named_param(command, argument name, name length, argument value, value length)` | Sets a named argument for the analytics query.
-| `lcb_cmdanalytics_positional_param(command, argument value, argument length)` | Adds a positional argument for the analytics query.
+| `lcb_cmdanalytics_positional_params(command, arguments as JSON string, argument string length)` | Adds positional arguments for the analytics query. _(From C SDK 3.2.1)_
+| `lcb_cmdanalytics_positional_param(command, argument value, argument length)` | Adds a positional argument for the analytics query. _(Will be deprecated from C SDK 3.3.0)_
 | `lcb_cmdanalytics_readonly(command, readonly)` | Marks analytics query as read-only ( set readonly value to non zero ).
 |====
 

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -50,7 +50,8 @@ Nevertheless, the result format recieved using an SDK may be different than that
 | `lcb_cmdquery_statement(command, statement, statement length )` | Sets the actual statement to be executed.
 | `lcb_cmdquery_scope_name(command, scope name, scope length)` | Associate scope name with the query.
 | `lcb_cmdquery_named_param(command, argument name, name length, argument value, value length)` | Sets a named argument for the query.
-| `lcb_cmdquery_positional_param(command, argument value, argument length)` | Adds a positional argument for the query.
+| `lcb_cmdquery_positional_params(command, arguments as JSON string, argument string length)` | Adds positional arguments for the query. _(From C SDK 3.2.1)_
+| `lcb_cmdquery_positional_param(command, argument value, argument length)` | Adds a positional argument for the query. _(Will be deprecated from C SDK 3.3.0)_
 | `lcb_cmdquery_readonly(command, readonly)` | Marks query as read-only ( set readonly value to non zero ).
 | `lcb_cmdquery_scan_cap(command, value)` | Sets maximum buffered channel size between the indexer client and the query service for index scans.
 | `lcb_cmdquery_flex_index(command, value)` | Tells the query engine to use a flex index (utilizing the search service).


### PR DESCRIPTION
PR for CCBC-1441. I've rewritten the singular version of query examples using the plural function instead.
(Not created a new one for analytics.)

Have added note about versions on singular and plural options in relevant tables.