### PR TITLE
Remove smart quotes

### DIFF
--- a/modules/concept-docs/pages/compression.adoc
+++ b/modules/concept-docs/pages/compression.adoc
@@ -34,7 +34,7 @@ Therefore, where necessary, enforce document size limits in your application on 
 
 == Operating Modes
 
-The three modes in which compression can be used, “off”, “passive” and “active”, are per bucket configuration settings on the cluster.
+The three modes in which compression can be used, "off", "passive" and "active", are per bucket configuration settings on the cluster.
 Depending on how it is set, the HELLO negotiation will fail or succeed.
 The `HELLO` flag for compression has the value `0x0a` and is defined as:
 

--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -33,7 +33,7 @@ For a full Search example, see the {lcb_api_link}/example_2fts_2fts_8c-example.h
 ////
 Search queries, facets, and sorting have a slightly different import from other components of `gocb`, you can import them using `import "github.com/couchbase/gocb/v2/search"`.
 
-Here is a simple MatchQuery that looks for the text “swanky” using a defined index:
+Here is a simple MatchQuery that looks for the text "swanky" using a defined index:
 
 [source,golang,indent=0]
 ----

--- a/modules/howtos/pages/observability-orphan-logger.adoc
+++ b/modules/howtos/pages/observability-orphan-logger.adoc
@@ -64,7 +64,7 @@ Each individual request has the following format:
 | `last_dispatch_duration_us` | The duration of the last dispatch span if present.
 | `total_dispatch_duration_us` | The duration of all dispatch spans, summed up.
 | `last_server_duration_us` | The server duration attribute of the last dispatch span, if present.
-| `operation_name` | The name of the outer request span, with “cb.” prefix removed.
+| `operation_name` | The name of the outer request span, with "cb." prefix removed.
 | `last_local_id` | The local_id from the last dispatch span, if present.
 | `operation_id` | The operation_id from the outer request span, if present.
 | `last_local_socket` | The local_address from the last dispatch span, if present.

--- a/modules/howtos/pages/slow-operations-logging.adoc
+++ b/modules/howtos/pages/slow-operations-logging.adoc
@@ -37,17 +37,17 @@ The overall structure looks like this (here prettified for readability):
 [source,json]
 ----
 {
-  “meta”: {
-	“emit_interval_s”: 600,
+  "meta": {
+	"emit_interval_s": 600,
   }
-  “<service-a>”: {
-      “total_count”: 1234,
-      “percentiles_us”: {
-        “50.0”: 5,
-        “90.0”: 10,
-        “99.0”: 33,
-        “99.9”: 55,
-        “100.0”: 101,
+  "<service-a>": {
+      "total_count": 1234,
+      "percentiles_us": {
+        "50.0": 5,
+        "90.0": 10,
+        "99.0": 33,
+        "99.9": 55,
+        "100.0": 101,
       }
     }
   },
@@ -87,8 +87,8 @@ You should expect to see output in JSON format in the logs for the services enco
 ----
 
 The `total_count` represents the total amount of over-threshold recorded items in each interval per service.
-The number of entries in “top_requests” is configured by the `sampleSize`.
-The service placeholder is replaced with each service -- “kv”, “query”, etc.
+The number of entries in "top_requests" is configured by the `sampleSize`.
+The service placeholder is replaced with each service -- "kv", "query", etc.
 Each entry looks like this, with all fields populated:
 
 [source,json]
@@ -119,7 +119,7 @@ It does not expose an external API to the application and is very focussed on it
 
 The way it works is that every time a response is in the process of being completed,
 when the SDK detects that the original caller is not listening anymore (likely because of a timeout),
-it will send this “orphan” response to a reporting utility which then aggregates it and in regular intervals logs them in a specific format.
+it will send this "orphan" response to a reporting utility which then aggregates it and in regular intervals logs them in a specific format.
 
 When the user then sees timeouts in their logs, they can go look at the output of the orphan reporter and correlate certain properties that aid debugging in production.
 For example, if a single node is slow but the rest of the cluster is responsive, this would be visible from orphan reporting.
@@ -136,19 +136,19 @@ The overall structure looks like this (here prettified for readability):
 [source,json]
 ----
 {
-  “<service-a>”: {
-    “total_count”: 1234,
-    “top_requests”: [{<entry>}, {<entry>},...]
+  "<service-a>": {
+    "total_count": 1234,
+    "top_requests": [{<entry>}, {<entry>},...]
   },
-  “<service-b>”: {
-    “total_count”: 1234,
-    “top_requests”: [{<entry>}, {<entry>},...]
+  "<service-b>": {
+    "total_count": 1234,
+    "top_requests": [{<entry>}, {<entry>},...]
   },
 }
 ----
 
 The total_count represents the total amount of recorded items in each interval per service.
-The number of entries in “top_requests” is configured by the sampleSize. The service placeholder is replaced with each service, i.e. “kv”, “query” etc.
+The number of entries in "top_requests" is configured by the sampleSize. The service placeholder is replaced with each service, i.e. "kv", "query" etc.
 Each entry looks like this, with all fields populated (same as the threshold logging):
 
 [source,json]
@@ -159,7 +159,7 @@ Each entry looks like this, with all fields populated (same as the threshold log
   "last_dispatch_duration_us": 40,
   "total_dispatch_duration_us": 40,
   "last_server_duration_us": 2,
-  “timeout_ms”: 75000,
+  "timeout_ms": 75000,
   "operation_name": "upsert",
   "last_local_id": "66388CF5BFCF7522/18CC8791579B567C",
   "operation_id": "0x23",

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -217,7 +217,7 @@ bucket.MutateIn("my_array", ops =>
 [source,csharp]
 ----
 bucket.MutateIn("my_array", ops =>
-    ops.ArrayAppend('', ['elem1', 'elem2', 'elem3']”)
+    ops.ArrayAppend('', ['elem1', 'elem2', 'elem3']")
 );
 # the document my_array is now ["some_element", ["elem1", "elem2", "elem3"]]
 ----
@@ -285,7 +285,7 @@ std::string value_to_add{ "42" };
 check(lcb_subdocspecs_array_add_last(specs, 0, 0, paths[0].c_str(), paths[0].size(), value_to_add.c_str(), value_to_add.size()),"create ARRAY_ADD_LAST operation");
 ----
 
-// for your examples, above, CD: “I feel like somewhere in this we should also just a an example path like "my.path[1]" too, just to show how to use the index with a nested path. I don't think it's necessarily clear.”
+// for your examples, above, CD: "I feel like somewhere in this we should also just a an example path like "my.path[1]" too, just to show how to use the index with a nested path. I don't think it's necessarily clear."
 
 Note that the array must already exist and that the index must be valid (i.e.
 it must not point to an element which is out of bounds).


### PR DESCRIPTION
Editing artefacts, Antora already smartens where needed, and this
makes some code examples not compile.

    perl -C -Mutf8 -pi -E 's/[”“]/"/g' modules/*/*/*.adoc

should do the trick.

(This was driveby for DOC-8974, but I've requested clarification on that ticket, so pushing this as separate fixup)