### PR TITLE
Add Support for ARMv8 on Ubuntu 20

### DIFF
--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -93,7 +93,7 @@ Although installable or compilable on many other platforms, we cannot provide su
 
 === ARM Processor Support
 
-Libcouchbase (C SDK) 3.3 supports AWS Amazon Graviton2 and Apple M1 ARM processors.
+Libcouchbase (C SDK) 3.3 supports AWS Amazon Graviton2, Apple M1 ARM processors, and ARMv8 on Ubuntu 20.04 (from SDK `3.3.3`).
 
 
 == Couchbase New Feature Availability Matrix


### PR DESCRIPTION
We shouldn't merge this until SDK 3.3.3 is ready to be released.