### PR TITLE
DOC-10496 - Document Platform Root CA Usage

### DIFF
--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -217,11 +217,33 @@ NOTE: Any TLS certificates must be set up at the point where the connections are
 [#ssl]
 == Secure Connections
 
-Couchbase Server Enterprise Edition supports full encryption of client-side traffic using Transport Layer Security (TLS). 
-This includes key-value type operations, queries, and configuration communication.  
-Make sure you have the Enterprise Edition of Couchbase Server before proceeding with configuring encryption on the client side.
+Couchbase Server Enterprise Edition and Couchbase Capella support full encryption of client-side traffic using Transport Layer Security (TLS).
+This includes key-value type operations, queries, and configuration communication.
+Make sure you have the Enterprise Edition of Couchbase Server, or a Couchbase Capella account, before proceeding with configuring encryption on the client side.
 
-To configure encryption for the C SDK (libcouchbase):
+[{tabs}]
+====
+Couchbase Capella::
++
+--
+The C SDK bundles Capella’s standard root certificate by default.
+This means you don’t need any additional configuration to enable TLS -- simply use `couchbases://` in your connection string.
+
+NOTE: Capella's root certificate is *not* signed by a well known CA (Certificate Authority).
+However, as the certificate is bundled with the SDK, it is trusted by default.
+--
+
+Couchbase Server::
++
+--
+As of SDK `3.3.3`, if you connect to a Couchbase Server cluster with a root certificate issued by a trusted CA (Certificate Authority), you no longer need to configure the `certpath` property in your connection string.
+
+The cluster's root certificate just needs to be issued by a CA whose certificate is in your system trust store.
+This includes publicly trusted CAs (e.g., GoDaddy, Verisign, etc...), plus any other CA certificates that you wish to add.
+
+IMPORTANT: C SDK loads your platform's root CA store using OpenSSL, therefore you should make sure that your system or platform is configured to support this.
+
+You can still provide a certificate explicitly if necessary:
 
 . Get the CA certificate from the cluster and save it in a text file.
 . Enable encryption on the client side and point it to the file containing the certificate.
@@ -232,7 +254,9 @@ side, so either copy it through SSH, or through a similar secure mechanism.
 If you are running on `localhost` and just want to enable TLS for a development machine, just copying and pasting it suffices
 -- _so long as you use `127.0.0.1` rather than `localhost` in the connection string_.
 This is because the certificate will not match the name _localhost_.
-Setting `TLSSkipVerify` is a workaround if you need to use ` couchbases://localhost`.
+
+// TODO: Not entirely sure this is correct, needs to be verified.
+//Setting `TLSSkipVerify` is a workaround if you need to use ` couchbases://localhost`.
  
 Navigate in the admin UI to menu:Settings[Cluster] and copy the input box of the TLS certificate into a file on your machine (which we will refer to as `cluster.cert`). 
 It looks similar to this:
@@ -278,11 +302,13 @@ E.....@.@.............+....Z.'yZ..#........
 ..... ...xuG.O=.#.........?.Q)8..D...S.W.4.-#....@7...^.Gk.4.t..C+......6..)}......N..m..o.3...d.,.     ...W.....U..
 .%v.....4....m*...A.2I.1.&.*,6+..#..#.5
 ----
+--
+====
 
 
 // == Using DNS SRV records
 
-include::6.5@sdk:shared:partial$dnssrv-pars.adoc[tag=dnssrv]
+include::{version-common}@sdk:shared:partial$dnssrv-pars.adoc[tag=dnssrv]
 
 The C SDK always tries to use the SRV records, if the connection string contains a single hostname and the feature is not
 disabled explicitly with connection string option `dnssrv=off`.
@@ -299,4 +325,4 @@ If the DNS SRV records could not be loaded properly you'll get an exception logg
 81ms [If1e0caf208c1ff41] {11763} [INFO] (instance - L:202) DNS SRV lookup failed: LCB_ERR_UNKNOWN_HOST (1049). Ignore this if not relying on DNS SRV records
 ----
 
-include::6.5@sdk:shared:partial$managing-connections.adoc[tag=cloud]
+include::{version-common}@sdk:shared:partial$managing-connections.adoc[tag=cloud]

--- a/modules/project-docs/partials/attributes.adoc
+++ b/modules/project-docs/partials/attributes.adoc
@@ -1,0 +1,2 @@
+:version-server: 7.1
+:version-common: 7.1.2


### PR DESCRIPTION
We shouldn't merge this until SDK 3.3.3 is ready to be released.