### PR TITLE
DOC-10474 - Update compat tables

### DIFF
--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -28,13 +28,7 @@ It is best to upgrade either the SDK or the Couchbase version you are using.
 |===
 | |SDK 3.0, 3.1 | 3.2 | 3.3
 
-| *Server 6.0*
-| *✔*
-| *✔*
-| *✔*
-
-
-| *Server 6.5-6.6*
+| *Server 6.6*
 | *✔*
 | *✔*
 | *✔*
@@ -55,10 +49,10 @@ See the notes there for Support details.
 
 === Capella Compatibility
 
-At time of release, the Couchbase 3.3 C SDK is fully compatible with Couchbase Capella, our fully-hosted database-as-a-service.
+The C SDK is fully compatible with Couchbase Capella, our fully-hosted database-as-a-service.
 Note, LCB does not bundle the Capella Client Certificate, follow the xref:server:guides:connect.adoc#tls[instructions] to download and install the certificate from Capella, then guide to xref:howtos:managing-connections.adoc#ssl[secure connections with LCB].
 
-include::{cb_server_version}@sdk:shared:partial$capella.adoc[tag=cloud]
+include::{version-common}@sdk:shared:partial$capella.adoc[tag=cloud]
 
 
 == Platform Compatibility
@@ -85,8 +79,8 @@ Any MS-supported version compatible with Visual Studio 2015 (VC14) or 2017 (VC15
 === Mac OS X
 
 The current and previous two releases of OS X.
-At time of writing (April 2022): 10.15 (_Catalina_), 11 (_Big Sur_), and 12 (_Monterey_).
-M1 ARM  architecture is fully supported in the 3.3 C SDK.
+At time of writing (October 2022): 13 (Ventura), 12 (Monterey), and 11 (Big Sur).
+M1 ARM  architecture is fully supported in the C SDK.
 ****
 
 Although installable or compilable on many other platforms, we cannot provide support for untested combinations.
@@ -100,35 +94,32 @@ Libcouchbase (C SDK) 3.3 supports AWS Amazon Graviton2 and Apple M1 ARM processo
 
 .Couchbase Server and SDK Supported Version Matrix
 [.table-merge-cells] 
-[cols="7,5,6,5"]
+[cols="7,6,5"]
 |===
-| | Server 6.0 | Server 6.5 & 6.6 | Server 7.0 & 7.1
+| | Server 6.5 & 6.6 | Server 7.0 & 7.1
 
 | Enhanced Durability
-3+| All SDK versions
+2+| All SDK versions
 
 | Durable Writes 
-| Not Supported
 2+| Since 3.0
 
 | Analytics
-3+| Since 2.10
+2+| Since 2.10
 
 | Distributed ACID Transactions
-| Not Supported
 2+| C++ Transactions 1.0.0 with Server 6.6 and upwardsfootnote:[{cpp} Transactions installs its own version of LCB.]
 
 | Collections
 | Not Supported
-| Developer Preview in 6.5-6.6, SDK 3.0
+| Developer Preview in 6.6, SDK 3.0
 | Since 3.0.6
 
 | Scope-Level N1QL Queries & all Collections features
-2+| Not Supported
+| Not Supported
 | Since SDK 3.2.0
 
 | Request Tracing
-| Not Supported
 2+| Since SDK 3.0.2
 |===
 


### PR DESCRIPTION
We shouldn't merge this until SDK 3.3.3 is ready to be released.