### PR TITLE
Changed the nomenclature -- FTS to Search

### DIFF
--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -1,5 +1,5 @@
-= Full Text Search (FTS) Using the C SDK with Couchbase Server
-:description: You can use the Full-Text Search service (FTS) to create queryable full-text indexes in Couchbase Server.
+= Search Service Using the C SDK with Couchbase Server
+:description: You can use the Search service to create queryable Search indexes in Couchbase Server.
 :navtitle: Searching from the SDK
 :page-topic-type: howto
 
@@ -8,14 +8,14 @@
 {description}
 
 
-Full-Text Search or FTS allows you to create, manage, and query full text indexes on JSON documents stored in Couchbase buckets.
+Search Service allows you to create, manage, and query Search indexes on JSON documents stored in Couchbase buckets.
 It uses natural language processing for querying documents, provides relevance scoring on the results of your queries, and has fast indexes for querying a wide range of possible text searches.
-Some of the supported query types include simple queries like Match and Term queries; range queries like Date Range and Numeric Range; and compound queries for conjunctions, disjunctions, and/or boolean queries.
-The C SDK exposes an API for performing FTS queries which abstracts some of the complexity of using the underlying REST API.
+Some of the supported query types include queries like Match and Term queries, range queries like Date Range and Numeric Range, compound queries for conjunctions, disjunctions, and boolean queries.
+The C SDK exposes an API for performing Search queries which abstracts some of the complexity of using the underlying REST API.
 
 NOTE: When using a Couchbase version < 6.5 you must create a valid Bucket connection using `cluster.Bucket(name)` before you can use Search.
 
-// As of Couchbase Server 6.5, FTS...
+// As of Couchbase Server 6.5, Search Service (FTS)...
 
 == Getting Started
 

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -125,7 +125,7 @@ For those occasions when you do, please see the relevant API docs:
 
 // * Query
 
-// * Search - note & link to FTS page & API?
+// * Search - note & link to FTS/Search Service page & API?
 
 == View Management
 

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-server:
+    branches: release/8.0
+  docs-devex:
+    branches: release/8.0


### PR DESCRIPTION
[DOC-14028](https://jira.issues.couchbase.com/browse/DOC-14028)

Changed the instances that said FTS to Search. 
Also added the preview directory and HEAD.yml file as the docs-sdk-c repo did not have these.

[Doc Preview](https://preview.docs-test.couchbase.com/docs-sdk-c-DOC-14028_C_FTS_to_Search_Namechange/c-sdk/current/howtos/full-text-searching-with-sdk.html)

[DOC-14028]: https://couchbasecloud.atlassian.net/browse/DOC-14028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ